### PR TITLE
Legal-entity disclosure footer (for Apple Developer support-case flag)

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -10,6 +10,8 @@ website:
   repo-url: https://github.com/samstevenm/diligentservices-quarto/
   repo-actions: [issue]
   favicon: images/favicon.ico
+  page-footer:
+    center: "Diligent Services is a DBA of Carmelita Enterprises Inc."
   navbar:
     left:
       - text: "Home"


### PR DESCRIPTION
Prepared by Jane for your review — **do not publish without review** (per the read-only-Quarto rule). One-line, low-risk site config change.

## Why
Apple Developer enrollment support-case flag (advisor Em, case **102924699998**): the site must clearly associate the operating brand "Diligent Services" with the enrolling legal entity. Today the homepage/About name only "Diligent Services" (About even references the old "DSI" / Diligent Services **Inc**, which is FTB-suspended) — never **Carmelita Enterprises Inc**.

## Change
Adds a site-wide Quarto `page-footer` to `_quarto.yml`:
```yaml
  page-footer:
    center: "Diligent Services is a DBA of Carmelita Enterprises Inc."
```
Shows on every page, including `/contact` — which is the support URL given to Apple.

## Also needed (not in this PR — it's a publish action, yours)
`contact.qmd` already exists (email + phone), but the **live `/contact` 404s because the published site is stale**. A `quarto render` + deploy brings it live and serves as the Apple support URL — **no new support page needed**. Merging this PR + republishing clears both of Em's notes.

## After publish
A reply to Apple case 102924699998 is staged + held as a Fastmail draft (cites `https://diligentservices.io/contact`); send it once the site is republished.

🤖 Generated with [Claude Code](https://claude.com/claude-code)