### PR TITLE
site: one canonical /g611/ colophon + fix Proxmox post year

### DIFF
--- a/_g611.qmd
+++ b/_g611.qmd
@@ -1,7 +1,1 @@
-##### A note on how this is made *(G611)*
-
-I lean on AI coding agents to build a lot of this. The site, and the apps it supports, are mostly written by an agent that I prompt, steer, and review. The ideas, the testing, the decisions, and the final call are mine.
-
-That's how I read Galatians 6:11: "Ye see how large a letter I have written unto you with mine own hand." Paul dictated most of his letters, then added a few words in his own hand so you knew he stood behind them. Same idea here. I use the tools, do my own diligence, and put my name on the result.
-
-Sam Myers
+*Parts of this are written with AI coding agents that I prompt, steer, and review. [A note on how this is made (G611)](/g611/).*

--- a/blog/Local-First-Control-For-Mitsubishi-Minisplit.qmd
+++ b/blog/Local-First-Control-For-Mitsubishi-Minisplit.qmd
@@ -60,4 +60,4 @@ This journey reflects our commitment at Diligent Services to find practical, eff
 I lean on tools like large language models to speed up my writing, refining this post with their help. The idea, research, and final edits are mine, though—my “hand” shapes the outcome. Check out [AI Slop, Suspicion, and Writing Back](https://benjamincongdon.me/blog/2025/01/25/AI-Slop-Suspicion-and-Writing-Back/) for a deeper take on this balance.  
 
 > **Standard Disclaimer**  
-This post blends human and AI effort (G611). I’ve reviewed it thoroughly, but always verify for yourself and consult pros when needed.
+This post blends human and AI effort [(G611)](/g611/). I’ve reviewed it thoroughly, but always verify for yourself and consult pros when needed.

--- a/blog/ProxMox-RemotePC.qmd
+++ b/blog/ProxMox-RemotePC.qmd
@@ -2,7 +2,7 @@
 title: "Setting Up Proxmox VE with Windows 10 Guest VM and DHCP Networking"
 description: "A step-by-step guide to setting up Proxmox VE on a mini PC, enabling DHCP networking with Tailscale, and preparing for guest OS installations."
 author: "Sam M"
-date: "2024-01-08"
+date: "2025-01-08"
 categories: 
   - Networking
   - VM
@@ -244,4 +244,4 @@ Organize credentials with relevant tags for easy retrieval.
 With Proxmox VE configured for DHCP networking and Tailscale integration, you have a stable base OS ready for hosting VMs and containers. This setup allows remote management and adaptability to any network, ensuring reliability and flexibility for your virtualized workloads.
 
 > **Standard Disclaimer**  
-This post is a mix of human and AI effort [(G611)](/blog/Selective-Mac-to-Mac-Migration-Using-rsync.qmd#author’s-note). While I’ve reviewed and finalized the content, some parts reflect AI-generated input. Always do your own due diligence and consult professionals when needed.  
+This post is a mix of human and AI effort [(G611)](/g611/). While I’ve reviewed and finalized the content, some parts reflect AI-generated input. Always do your own due diligence and consult professionals when needed.  

--- a/blog/Selective-Mac-to-Mac-Migration-Using-rsync.qmd
+++ b/blog/Selective-Mac-to-Mac-Migration-Using-rsync.qmd
@@ -316,5 +316,5 @@ I'm reminded of Galatians 6:11: “Ye see how large a letter I have written unto
 After I wrote this, but before publishing, I read a thoughtful piece aptly titled [AI Slop, Suspicion, and Writing Back](https://benjamincongdon.me/blog/2025/01/25/AI-Slop-Suspicion-and-Writing-Back/) on AI writing which provides a much more nuanced take on this complex issue, and was valuable to me as I figure out where I stand.
 
 > **Standard Disclaimer**  
-This post is a mix of human and AI effort (G611). While I’ve reviewed and finalized the content, some parts reflect AI-generated input. Always do your own due diligence and consult professionals when needed.  
+This post is a mix of human and AI effort [(G611)](/g611/). While I’ve reviewed and finalized the content, some parts reflect AI-generated input. Always do your own due diligence and consult professionals when needed.  
 

--- a/g611/index.qmd
+++ b/g611/index.qmd
@@ -1,0 +1,14 @@
+---
+title: "A note on how this is made (G611)"
+format:
+  html:
+    toc: false
+---
+
+I lean on AI coding agents to build a lot of this. The site, and the apps it supports, are mostly written by an agent that I prompt, steer, and review. The ideas, the testing, the decisions, and the final call are mine.
+
+That's how I read Galatians 6:11: "Ye see how large a letter I have written unto you with mine own hand." Paul dictated most of his letters, then added a few words in his own hand so you knew he stood behind them. Same idea here. I use the tools, do my own diligence, and put my name on the result.
+
+After I started writing notes like this one, I read a thoughtful piece aptly titled [AI Slop, Suspicion, and Writing Back](https://benjamincongdon.me/blog/2025/01/25/AI-Slop-Suspicion-and-Writing-Back/), which gives a much more nuanced take on this whole question and was valuable to me as I figure out where I stand.
+
+Sam Myers

--- a/support/index.qmd
+++ b/support/index.qmd
@@ -15,10 +15,4 @@ Have a question about a Diligent Services app or project? Get in touch and I'll 
 
 ---
 
-##### A note on how this is made *(G611)*
-
-I lean on AI coding agents to build a lot of this. The site, and the apps it supports, are mostly written by an agent that I prompt, steer, and review. The ideas, the testing, the decisions, and the final call are mine.
-
-That's how I read Galatians 6:11: "Ye see how large a letter I have written unto you with mine own hand." Paul dictated most of his letters, then added a few words in his own hand so you knew he stood behind them. Same idea here. I use the tools, do my own diligence, and put my name on the result.
-
-Sam Myers
+{{< include ../_g611.qmd >}}


### PR DESCRIPTION
Two corrections to the site. **Review-gated — please review before I deploy.** Nothing is live until you merge and I run the `quarto render` + nginx reload on Hetzner.

## FIX 1 — Proxmox post year
`blog/ProxMox-RemotePC.qmd`: frontmatter `date: "2024-01-08"` → `"2025-01-08"`. The wrong year was sorting this post ahead of the actual Jan-2025 work. Now renders as **January 8, 2025**.

## FIX 2 — G611 colophon consolidation
The "Galatians 6:11 (G611)" AI-authorship note was fragmented across five files, each worded differently, and the Proxmox `(G611)` linked a **broken cross-post anchor** (`Selective-Mac-to-Mac-Migration-Using-rsync.qmd#author's-note`). Now there is one canonical note.

- **New `g611/index.qmd` → clean URL `/g611/`** — the full colophon plus a closing link to Benjamin Congdon's [*AI Slop, Suspicion, and Writing Back*](https://benjamincongdon.me/blog/2025/01/25/AI-Slop-Suspicion-and-Writing-Back/).
- **`_g611.qmd` is now a short include** that points at `/g611/` instead of duplicating the whole note.
- **`support/index.qmd`** uses that include instead of inlining the full note.
- **Every `(G611)` mark repointed to `/g611/`**: Proxmox (broken anchor → fixed), Local-First Part 1, and the Mac-to-Mac post. The two blog posts keep their own personal "Author's Note" prose; only the `(G611)` token now links to the canonical page.

Quarto rewrites the root-relative `/g611/` to the correct relative path (`../g611/`) from every page.

## Verified locally (`quarto render`, Quarto 1.9.38)
- `/g611/` renders with the colophon, the Galatians quote, the Congdon link, and the signature.
- Support page: include resolves, full note no longer duplicated, link → `../g611/`.
- Proxmox / Local-First / Mac-to-Mac: `(G611)` → `../g611/`; no leftover broken anchor; Proxmox date = 2025-01-08.

## After you merge (deploy — I'll run it on your OK)
SSH `root@100.117.67.14` → `cd /var/www/diligentservices/diligentservices-quarto` → `git merge --ff-only origin/main` → `source .venv/bin/activate` → `quarto render` → `systemctl reload nginx`, then verify the footer, `/support`, and `/g611/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)