### PR TITLE
Redesign: reposition home + IA → luxury lighting & control integration

### DIFF
--- a/EDITING.md
+++ b/EDITING.md
@@ -111,14 +111,19 @@ publish it. The site runs on the company's web server (Hetzner). The steps:
    (`git add <files you changed>`, `git commit -m "update copy"`, `git push`).
 2. Connect to the server over SSH (the login key is stored in the company
    1Password under "Hetzner | root | diligentservices.io").
-3. On the server:
+3. On the server, run the safe publish script:
    ```bash
    cd /var/www/diligentservices/diligentservices-quarto
-   git pull
-   source .venv/bin/activate   # required, or the blog posts fail to build
-   quarto render
+   ./publish.sh
    ```
-   The web server serves the freshly rendered `_site/` folder. No restart needed.
+   `publish.sh` backs up the current live site, pulls, renders, and — if any step
+   fails — automatically restores the previous version, so the live site is never
+   left half-broken. It prints the previous commit so you can roll back later. The
+   web server serves the rendered `_site/` folder directly; no restart needed.
+
+   (Raw steps it runs, if you ever need them by hand: `git pull`, then
+   `source .venv/bin/activate` — required, or the computational blog posts fail —
+   then `quarto render`.)
 
 > **Review before publish.** Public, client-facing copy should be read over (and,
 > for blog posts, approved by Sam) before this publish step. When in doubt, preview
@@ -126,7 +131,27 @@ publish it. The site runs on the company's web server (Hetzner). The steps:
 
 ---
 
-## 8. House rules
+## 8. Roll back a bad change
+
+Every published version is just a git commit, so nothing is ever truly lost — you
+can always put the previous version back, usually in under a minute. On the server:
+
+```bash
+cd /var/www/diligentservices/diligentservices-quarto
+git log --oneline          # find the last good commit (publish.sh also prints it)
+./rollback.sh <commit>     # e.g. ./rollback.sh dc8e93d
+```
+
+`rollback.sh` checks out that commit and re-renders, so the live site looks exactly
+like it did then. When you've fixed the problem and want to move forward again:
+
+```bash
+git checkout main && ./publish.sh
+```
+
+---
+
+## 9. House rules
 
 - **No client names or project specifics** on the public site unless you have
   written permission. Keep capability copy generic.

--- a/EDITING.md
+++ b/EDITING.md
@@ -1,0 +1,136 @@
+# Editing the Diligent Services website
+
+This site is a small [Quarto](https://quarto.org) site. Every page is a plain text
+file you can edit by hand. You do **not** need to be a programmer to update the
+words, the contact details, or the colors. This guide walks through the common
+changes step by step.
+
+> **Golden rule:** edit the text, preview it, then publish. Nothing you type goes
+> live until you run the publish step at the bottom.
+
+---
+
+## 1. Which file is which page?
+
+| To change this page... | Edit this file |
+|---|---|
+| Home | `index.qmd` |
+| Services | `services.qmd` |
+| About Us | `about.qmd` |
+| Contact | `contact.qmd` |
+| Support | `support/index.qmd` |
+| Blog (the list) | `blog/index.qmd` |
+| A blog post | the matching file in `blog/` |
+| The menu, footer, contact email/phone | `_quarto.yml` |
+| Colors and fonts | `styles/custom.scss` |
+| The "made with AI" note (G611) | `_g611.qmd` |
+
+Each `.qmd` file starts with a small block between `---` lines (the "front
+matter", which sets the title) followed by the page text written in **Markdown**.
+
+---
+
+## 2. Change the words on a page
+
+1. Open the file from the table above in any text editor.
+2. Below the `---` block, edit the text. Markdown basics:
+   - `## A Heading` makes a section heading.
+   - `- item` makes a bullet. `**bold**` makes bold text.
+   - `[link text](contact.qmd)` makes a link to another page.
+3. Save the file, then **preview** (section 5) and **publish** (section 6).
+
+Keep these lines exactly as they are wherever they appear, they are required:
+
+- `Diligent Services is a DBA of Carmelita Enterprises Inc.`
+- the CSLB license number `1132892`
+
+---
+
+## 3. Change the menu, footer, email, or phone
+
+Open `_quarto.yml`.
+
+- **Menu items** live under `navbar:` `left:`. Each item has a `text:` (what shows)
+  and an `href:` (which file it opens).
+- **Footer** lives under `page-footer:`. The `center:` line is the required legal
+  line, leave it as is.
+- **Email / phone** show on the Contact and Support pages, edit those files
+  (`contact.qmd`, `support/index.qmd`). The little email icon in the top-right menu
+  is the `mailto:` line near the bottom of `_quarto.yml`.
+
+---
+
+## 4. Change the colors or fonts
+
+Open `styles/custom.scss`. The top section has a short list of named colors with
+comments, for example:
+
+```scss
+$ds-cream:  #FBF9F4;  // page background (warm off-white)
+$ds-brass:  #9A6B1E;  // the one warm accent (buttons, active nav, rules)
+```
+
+Change a `#` hex value to recolor the site, then preview. To change a font, update
+the two `font-family` lines here **and** the Google Fonts `<link>` near the bottom
+of `_quarto.yml` so the new font actually loads.
+
+---
+
+## 5. Add a blog post
+
+1. Copy an existing post in `blog/` to a new file, e.g. `blog/my-new-post.qmd`.
+2. Edit the front matter at the top: `title`, `date`, `description`, and the
+   `categories`.
+3. Write the post in Markdown below the front matter.
+4. Preview, then publish. The post appears on the Blog page automatically.
+
+(There is a longer how-to post already in the blog:
+"How to Create and Publish a Quarto Blog Post".)
+
+---
+
+## 6. Preview your changes locally
+
+From a terminal, in the project folder:
+
+```bash
+quarto preview
+```
+
+This opens the site in your browser and refreshes as you save. Press `Ctrl+C` to
+stop. Use this to check your edits before publishing.
+
+---
+
+## 7. Publish to the live site
+
+The live site does **not** update automatically when you save or push, you have to
+publish it. The site runs on the company's web server (Hetzner). The steps:
+
+1. Commit and push your changes to GitHub
+   (`git add <files you changed>`, `git commit -m "update copy"`, `git push`).
+2. Connect to the server over SSH (the login key is stored in the company
+   1Password under "Hetzner | root | diligentservices.io").
+3. On the server:
+   ```bash
+   cd /var/www/diligentservices/diligentservices-quarto
+   git pull
+   source .venv/bin/activate   # required, or the blog posts fail to build
+   quarto render
+   ```
+   The web server serves the freshly rendered `_site/` folder. No restart needed.
+
+> **Review before publish.** Public, client-facing copy should be read over (and,
+> for blog posts, approved by Sam) before this publish step. When in doubt, preview
+> and ask first.
+
+---
+
+## 8. House rules
+
+- **No client names or project specifics** on the public site unless you have
+  written permission. Keep capability copy generic.
+- Keep the **DBA legal line** and the **CSLB 1132892** number wherever they appear.
+- Keep the **`/support`** page live with a working email link, an app store requires it.
+- The AI-authorship note (`_g611.qmd`, shown on Support) stays for any page that is
+  largely written with AI help.

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -6,12 +6,12 @@ project:
 website:
   title: "Diligent Services"
   site-url: https://diligentservices.io
-  description: "Diligent Services designs, programs, and maintains the lighting, control, and entertainment systems behind Southern California's finest homes. Lighting & control integration, based in the Greater Los Angeles area."
+  description: "Diligent Services designs, installs, and programs lighting, AV, control, and networking for high-end residential and commercial spaces across California and Nevada. A DBA of Carmelita Enterprises Inc, CSLB 1132892."
   repo-url: https://github.com/samstevenm/diligentservices-quarto/
   repo-actions: [issue]
   favicon: images/favicon.ico
   page-footer:
-    left: "Diligent Services · Lighting & Control Integration · Southern California"
+    left: "Diligent Services · Lighting & Control Integration · California & Nevada"
     center: "Diligent Services is a DBA of Carmelita Enterprises Inc."
     right:
       - text: "Support"

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -43,7 +43,7 @@ website:
 format:
   html:
     theme:
-      - darkly
+      - cosmo
       - styles/custom.scss
     toc: true
     include-in-header:

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -18,6 +18,8 @@ website:
         href: support/index.qmd
       - text: "Contact"
         href: contact.qmd
+      - text: "How this site is made"
+        href: g611/index.qmd
   navbar:
     left:
       - text: "Home"

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -6,16 +6,24 @@ project:
 website:
   title: "Diligent Services"
   site-url: https://diligentservices.io
-  description: "Diligent Services is a consulting company that specializes in building bespoke solutions."
+  description: "Diligent Services designs, programs, and maintains the lighting, control, and entertainment systems behind Southern California's finest homes. Lighting & control integration, based in the Greater Los Angeles area."
   repo-url: https://github.com/samstevenm/diligentservices-quarto/
   repo-actions: [issue]
   favicon: images/favicon.ico
   page-footer:
+    left: "Diligent Services · Lighting & Control Integration · Southern California"
     center: "Diligent Services is a DBA of Carmelita Enterprises Inc."
+    right:
+      - text: "Support"
+        href: support/index.qmd
+      - text: "Contact"
+        href: contact.qmd
   navbar:
     left:
       - text: "Home"
         href: index.qmd
+      - text: "Services"
+        href: services.qmd
       - text: "About"
         href: about.qmd
       - text: "Blog"
@@ -34,12 +42,12 @@ website:
 
 format:
   html:
-    theme: 
-      - journal 
-    # Here are some bootstrap theme options:
-    #   default, cerulean, cosmo, cyborg, darkly, flatly, journal, 
-    #   litera, lumen, lux, materia, minty, morph, pulse, quartz,
-    #   sandstone, simplex, sketchy, slate, solar, spacelab, superhero,
-    #   united, vapor, yeti, zephyr
+    theme:
+      - darkly
       - styles/custom.scss
-    css: styles/custom.scss
+    toc: true
+    include-in-header:
+      - text: |
+          <link rel="preconnect" href="https://fonts.googleapis.com">
+          <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+          <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">

--- a/about.qmd
+++ b/about.qmd
@@ -10,11 +10,11 @@ toc: true
 
 ---
 
-Diligent Services is a family-run lighting and control integration firm (_[CSLB 1132892](https://www.cslb.ca.gov/OnlineServices/checklicenseII/LicenseDetail.aspx?LicNum=1132892)_) serving high-end residential and commercial clients across California and Nevada. Founded in 2002 by Tony and Barbara Myers in the SF Bay Area, the operation is now run by Sam and Pearl Myers. We design, install, and program lighting, audio/visual, control, and networking systems - the quiet infrastructure that makes a luxury home or a refined commercial space feel effortless. Our work runs from private estates to luxury retail and hospitality interiors, and we thrive on referral business.
+Diligent Services is a family-run lighting and control integration firm (_[CSLB 1132892](https://www.cslb.ca.gov/OnlineServices/checklicenseII/LicenseDetail.aspx?LicNum=1132892)_) serving high-end residential and commercial clients. Founded in 2002 by Tony and Barbara Myers in the SF Bay Area, the operation is now run by Sam and Pearl Myers. We design, install, and program lighting, audio/visual, control, and networking - the quiet infrastructure that makes a home or a commercial space feel effortless. We thrive on referral business.
 
 ### Personal Touch
 
-Diligent Services is a family operation founded by Tony and Barbara Myers, and actively supported by the immediate and extended Myers Family. We treat every project the way we'd treat our own - in fact, our own reference installation is a 22-zone Savant and Lutron home we live in and learn from. The name Diligent Services was chosen carefully, as we strive to follow Colossians 3:23: "Whatever you do, work at it with all your heart, as working for the Lord, not for human masters."
+Diligent Services is a family operation founded by Tony and Barbara Myers, and actively supported by the immediate and extended Myers Family. We treat every project the way we'd treat our own. The name Diligent Services was chosen carefully, as we strive to follow Colossians 3:23: "Whatever you do, work at it with all your heart, as working for the Lord, not for human masters."
 
 ---
 

--- a/about.qmd
+++ b/about.qmd
@@ -10,15 +10,11 @@ toc: true
 
 ---
 
-Diligent Services is a family-run systems integrator based in the Greater Los Angeles area. We design, program, and maintain the lighting, audio/visual, and control systems behind high-end Southern California homes.
-
-What began as a family general-contracting and remodeling business (licensed in California, _[CSLB 1132892](https://www.cslb.ca.gov/OnlineServices/checklicenseII/LicenseDetail.aspx?LicNum=1132892)_) has grown into an integration practice. That trade background is the point of difference: our systems are specified to work with the house - its wiring, its structure, its finishes - instead of being added on afterward.
+Diligent Services is a family-run lighting and control integration firm (_[CSLB 1132892](https://www.cslb.ca.gov/OnlineServices/checklicenseII/LicenseDetail.aspx?LicNum=1132892)_) serving high-end residential and commercial clients across California and Nevada. Founded in 2002 by Tony and Barbara Myers in the SF Bay Area, the operation is now run by Sam and Pearl Myers. We design, install, and program lighting, audio/visual, control, and networking systems - the quiet infrastructure that makes a luxury home or a refined commercial space feel effortless. Our work runs from private estates to luxury retail and hospitality interiors, and we thrive on referral business.
 
 ### Personal Touch
 
-Diligent Services is a family operation founded by Tony and Barbara Myers, and actively supported by the immediate and extended Myers Family. Much of the (large) Myers family lives in the Los Angeles area - family get-togethers often turn into family projects and vice versa. The name Diligent Services was chosen carefully, as we strive to follow Colossians 3:23: "Whatever you do, work at it with all your heart, as working for the Lord, not for human masters."
-
-We stand behind our systems long after the install crew leaves, because in this work, support is the product.
+Diligent Services is a family operation founded by Tony and Barbara Myers, and actively supported by the immediate and extended Myers Family. We treat every project the way we'd treat our own - in fact, our own reference installation is a 22-zone Savant and Lutron home we live in and learn from. The name Diligent Services was chosen carefully, as we strive to follow Colossians 3:23: "Whatever you do, work at it with all your heart, as working for the Lord, not for human masters."
 
 ---
 

--- a/about.qmd
+++ b/about.qmd
@@ -1,21 +1,24 @@
 ---
 title: "About Us"
+pagetitle: "About — Diligent Services"
 about:
   template: marquee
-format:
-  html:
-    toc: true
+toc: true
 ---
 
 ### Diligent Services
 
 ---
 
-Diligent Services is a full-service General Contracting (_[CSLB 1132892](https://www.cslb.ca.gov/OnlineServices/checklicenseII/LicenseDetail.aspx?LicNum=1132892)_) and Consulting firm. Founded in 2002 by Tony Myers in the SF Bay Area, the operation has since moved to the Greater Los Angeles area. DSI specializes in interior remodeling, revamping existing spaces like kitchens and bathrooms, and has recently been focused on developing bespoke solutions for custom technology and integration needs. We thrive on referral business.
+Diligent Services is a family-run systems integrator based in the Greater Los Angeles area. We design, program, and maintain the lighting, audio/visual, and control systems behind high-end Southern California homes.
+
+What began as a family general-contracting and remodeling business (licensed in California, _[CSLB 1132892](https://www.cslb.ca.gov/OnlineServices/checklicenseII/LicenseDetail.aspx?LicNum=1132892)_) has grown into an integration practice. That trade background is the point of difference: our systems are specified to work with the house - its wiring, its structure, its finishes - instead of being added on afterward.
 
 ### Personal Touch
 
 Diligent Services is a family operation founded by Tony and Barbara Myers, and actively supported by the immediate and extended Myers Family. Much of the (large) Myers family lives in the Los Angeles area - family get-togethers often turn into family projects and vice versa. The name Diligent Services was chosen carefully, as we strive to follow Colossians 3:23: "Whatever you do, work at it with all your heart, as working for the Lord, not for human masters."
+
+We stand behind our systems long after the install crew leaves, because in this work, support is the product.
 
 ---
 

--- a/contact.qmd
+++ b/contact.qmd
@@ -6,10 +6,10 @@ toc: false
 
 ### Let's design something quietly extraordinary.
 
-Planning a new home, a remodel, or an upgrade to the systems you already live with? Tell us about the space and how you want to live in it, and we'll take it from there.
+Most of our work starts with a conversation. Tell us about the space - a home, an estate, a retail or hospitality interior - and what you want it to do, and we'll talk through what good lighting and control look like for it before anyone quotes a thing. We work with clients and their builders, architects, and designers across California and Nevada.
 
 - **Email:** [info@diligentservices.io](mailto:info@diligentservices.io)
 - **Phone:** (424) 448-5200
-- **Service area:** Greater Los Angeles Area, CA
+- **Service area:** California and Nevada
 
 Already a client and need a hand? Head to [Support](support/index.qmd).

--- a/contact.qmd
+++ b/contact.qmd
@@ -1,15 +1,15 @@
 ---
 title: "Contact Us"
-format:
-  html:
-    toc: true
+pagetitle: "Contact — Diligent Services"
+toc: false
 ---
 
+### Let's design something quietly extraordinary.
 
-### Contact Us
+Planning a new home, a remodel, or an upgrade to the systems you already live with? Tell us about the space and how you want to live in it, and we'll take it from there.
 
-Ready to transform your space or incorporate smart home technology? Contact Diligent Services today to discuss your project and discover how we can help you achieve your vision.
+- **Email:** [info@diligentservices.io](mailto:info@diligentservices.io)
+- **Phone:** (424) 448-5200
+- **Service area:** Greater Los Angeles Area, CA
 
-- **Email**: info@diligentservices.io
-- **Phone**: (424) 448-5200
-- **Address:** Greater Los Angeles Area, CA
+Already a client and need a hand? Head to [Support](support/index.qmd).

--- a/contact.qmd
+++ b/contact.qmd
@@ -4,9 +4,9 @@ pagetitle: "Contact — Diligent Services"
 toc: false
 ---
 
-### Let's design something quietly extraordinary.
+### Let's talk.
 
-Most of our work starts with a conversation. Tell us about the space - a home, an estate, a retail or hospitality interior - and what you want it to do, and we'll talk through what good lighting and control look like for it before anyone quotes a thing. We work with clients and their builders, architects, and designers across California and Nevada.
+Most of our work starts with a conversation. Tell us about your space - a home or a commercial interior - and what you want it to do, and we will take it from there.
 
 - **Email:** [info@diligentservices.io](mailto:info@diligentservices.io)
 - **Phone:** (424) 448-5200

--- a/index.qmd
+++ b/index.qmd
@@ -1,132 +1,30 @@
 ---
+title: "Light. Control. Effortless."
+subtitle: "Lighting and control integration for high-end homes and commercial spaces."
 pagetitle: "Diligent Services — Lighting & Control Integration"
-description: "Diligent Services designs, installs, and programs lighting, AV, control, and networking for high-end residential and commercial spaces across California and Nevada. A DBA of Carmelita Enterprises Inc, CSLB 1132892."
-page-layout: full
 toc: false
-anchor-sections: false
 ---
 
-::: {.hero}
-[Lighting & Control Integration · California & Nevada]{.hero-eyebrow}
+Diligent Services designs, installs, and programs the lighting, audio/visual, control, and networking systems that make a space feel effortless. We are a small, family-run firm, and we carry a project from design through programming and the support that follows, so the technology stays out of the way.
 
-[Light. Control.<br>Effortless.]{.hero-title}
+[Start a project](contact.qmd){.btn .btn-primary} [See our services](services.qmd){.btn .btn-outline-secondary}
 
-[We design, install, and program lighting, audio/visual, control, and networking for high-end homes and commercial spaces across California and Nevada. Quiet to operate, considered in every detail, built to disappear into the room.]{.hero-sub}
+## What we do
 
-[Start a project](contact.qmd){.btn-cta} [See our capabilities](services.qmd){.btn-ghost}
-:::
+- **Lighting and tunable light.** Layered, dimmable, full-spectrum lighting, designed and programmed to suit a room at every hour.
+- **Audio and visual.** Distributed audio, media rooms, and displays, integrated and tuned to the space.
+- **Control and automation.** One simple interface for lighting, shades, climate, and media.
+- **Networking and infrastructure.** The structured wiring and reliable network everything else depends on.
 
-<hr class="rule">
+## Why Diligent Services
 
-::: {.section}
-[What we do]{.section-kicker}
+- **One accountable team.** Design, programming, installation, and support under one roof.
+- **We specify and program.** We design the system and write the programming, then stand behind it.
+- **Family-run since 2002.** A small team that earns the next project by referral.
+- **Licensed in California.** Carmelita Enterprises Inc, CSLB 1132892.
 
-[Four disciplines, integrated as one system. We specify and program platforms such as Lutron, Savant, and Ketra, then make them work together so a residence, a retail floor, or a hospitality venue behaves as a single, calm whole.]{.section-lead}
+## Ready to start?
 
-::: {.pillars}
-::: {.pillar}
-[01]{.ix}
+Tell us about your space and how you want it to work, and we will take it from there.
 
-### Lighting & Tunable Light
-
-Layered, dimmable, color-tunable lighting that flatters a room and follows the day. The same discipline serves a private residence, a retail boutique, or a hospitality floor.
-:::
-::: {.pillar}
-[02]{.ix}
-
-### Audio / Visual
-
-Distributed audio and video that reads cleanly in living spaces and across commercial properties, with sources, displays, and acoustics resolved before a single wire is pulled.
-:::
-::: {.pillar}
-[03]{.ix}
-
-### Control & Automation
-
-One interface for light, shade, climate, and media, so a home or a venue responds to a single touch, a schedule, or a scene without anyone tending it.
-:::
-::: {.pillar}
-[04]{.ix}
-
-### Networking & Infrastructure
-
-The wired and wireless backbone every other system depends on: structured cabling, resilient networks, and clean racks sized for homes and commercial sites alike.
-:::
-:::
-:::
-
-<hr class="rule">
-
-::: {.section}
-[Why Diligent Services]{.section-kicker}
-
-::: {.why}
-::: {.tile}
-### Resi-mercial range
-
-Luxury residences and commercial spaces, from active-adult communities in Northern California to retail and hospitality work across California and Nevada.
-:::
-::: {.tile}
-### Family-run, since 2002
-
-Founded by Tony and Barbara Myers, run today by Sam and Pearl Myers. A small team that answers for its own work and earns the next project by referral.
-:::
-::: {.tile}
-### We specify and program
-
-Not box-movers. We design the system, integrate the platforms, write the programming, and commission it so it holds up after we leave.
-:::
-::: {.tile}
-### Licensed in California
-
-Carmelita Enterprises Inc, CSLB 1132892. Accountable and documented from proposal through closeout.
-:::
-:::
-:::
-
-<hr class="rule">
-
-::: {.section}
-[Selected work]{.section-kicker}
-
-[A working portfolio across California and Nevada, from luxury residential to commercial and hospitality. We design, program, and stand behind lighting and control on platforms including Lutron, Savant, and Ketra.]{.section-lead}
-
-::: {.work}
-::: {.work-card}
-[Builder programs]{.cat}
-
-### A multi-year program across Northern California
-
-We run an ongoing, multi-home program for a national homebuilder's luxury active-adult communities in the greater Sacramento region, delivering repeatable lighting, shading, and network packages across dozens of homes with full change-order support.
-:::
-::: {.work-card}
-[Commercial & retail]{.cat}
-
-### Lighting control for a globally recognized brand
-
-We're the lighting-control specialist on luxury retail boutiques for a globally recognized brand, modernizing aging proprietary control to a current Lutron platform with custom-engraved keypads and scene control, on tight overnight windows that keep flagship stores trading.
-:::
-::: {.work-card}
-[Hospitality · in development]{.cat}
-
-### Modernizing lighting for hospitality & nightlife
-
-We migrate legacy panel-based dimming in hospitality and nightlife venues to a current Lutron HomeWorks platform with tunable, dynamic feature lighting and remote-supportable scene control, so a venue can refresh its look without re-pulling its existing infrastructure.
-:::
-::: {.work-card}
-[Our reference estate]{.cat}
-
-### The 22-zone home where we prove every approach
-
-Our own reference installation is a 22-zone residence where we run Savant control over Lutron lighting end to end, the home we use to prove and refine every lighting, shading, and control approach before we put it in a client's space.
-:::
-:::
-
-[Client names withheld by agreement. We're glad to walk you through relevant work on a call.]{.work-note}
-:::
-
-::: {.closing}
-## Let's design something quietly extraordinary.
-
-[Start a project](contact.qmd){.btn-cta}
-:::
+[Get in touch](contact.qmd){.btn .btn-primary}

--- a/index.qmd
+++ b/index.qmd
@@ -1,29 +1,86 @@
 ---
-title: "Welcome to Diligent Services"
-format:
-  html:
-    toc: true
+pagetitle: "Diligent Services — Lighting & Control Integration"
+description: "Lighting, control, and entertainment systems for Southern California's finest homes, designed and programmed and maintained by one accountable team."
+page-layout: full
+toc: false
+anchor-sections: false
 ---
-### Our Services
 
-- **Interior Remodeling:** Transforming kitchens, bathrooms, and living spaces to enhance functionality and aesthetics.
-- **Smart Home Technology:** Integrating modern smart home systems for convenience, security, and energy efficiency.
-- **Custom Projects:** Tailoring solutions to meet unique client needs and preferences, ensuring high satisfaction.
-- **Luxury AV Services:** Providing high-end audio-visual solutions to elevate your home entertainment experience.
-- **Home Automation Systems:** Implementing cutting-edge technology to automate and control various aspects of your home.
-- **Commercial Construction:** Managing and executing commercial construction and renovation projects with a focus on quality and efficiency.
-- **Technical Consulting:** Delivering expert advice on complex technical issues to enhance user experience and project outcomes.
+::: {.hero}
+[Lighting & Control Integration · Southern California]{.hero-eyebrow}
 
-### Why Choose Us
+[Light. Control.<br>Effortless living.]{.hero-title}
 
-- **Experience and Expertise:** Over 20 years of experience in general contracting and a deep understanding of modern construction and renovation techniques.
-- **Family Values:** A family-operated business with a commitment to integrity, trust, and exceptional service.
-- **Client-Centered Approach:** We prioritize our clients' needs and preferences, providing personalized solutions and attentive service.
+[Diligent Services designs, programs, and maintains the lighting, control, and entertainment systems that make Southern California's finest homes feel effortless. One accountable team, from design through the years of support that follow.]{.hero-sub}
 
-### Our Mission
+[Request a consultation](contact.qmd){.btn-cta} [See what we do](services.qmd){.btn-ghost}
+:::
 
-At Diligent Services, our mission is to deliver top-quality construction, renovation, and consulting services with a focus on excellence, integrity, and customer satisfaction. We aim to create spaces that are not only beautiful but also functional and reflective of our clients' lifestyles and values.
+<hr class="rule">
 
-### Blog
+::: {.section}
+[What we do]{.section-kicker}
 
-Check out our blog for updates on the latest trends in construction, smart home technology, and luxury AV services. Or, more likely, sporadic posts on whatever Sam finds interesting.
+[We don't sell boxes. We design systems: specified, programmed, and documented so the technology serves the home instead of the other way around.]{.section-lead}
+
+::: {.pillars}
+::: {.pillar}
+[01]{.ix}
+
+### Lighting & Tunable Light
+
+Layered scenes, motorized shades, and warm-to-cool tuning that shifts with the day. Lighting designed to read as architecture rather than gadgetry.
+:::
+::: {.pillar}
+[02]{.ix}
+
+### Audio / Visual
+
+Reference-grade media rooms, distributed audio, and theaters tuned to the room they live in.
+:::
+::: {.pillar}
+[03]{.ix}
+
+### Control & Automation
+
+One calm interface that unifies lighting, climate, shades, AV, and security. Simple enough for everyone in the house to use.
+:::
+::: {.pillar}
+[04]{.ix}
+
+### Networking & Infrastructure
+
+Enterprise-grade Wi-Fi, structured wiring, and the quiet, reliable backbone every connected home actually runs on.
+:::
+:::
+:::
+
+<hr class="rule">
+
+::: {.section}
+[Why Diligent Services]{.section-kicker}
+
+::: {.why}
+::: {.tile}
+### One accountable team
+
+Design, programming, installation, and support under one roof, so nothing falls between trades.
+:::
+::: {.tile}
+### Built to be serviced
+
+Every system labeled, documented, and supportable. When something needs attention, we answer.
+:::
+::: {.tile}
+### We put our name on it
+
+A family operation that stands behind the work. Licensed in California, and around long after the install crew leaves.
+:::
+:::
+:::
+
+::: {.closing}
+## Let's design something quietly extraordinary.
+
+[Request a consultation](contact.qmd){.btn-cta}
+:::

--- a/index.qmd
+++ b/index.qmd
@@ -1,19 +1,19 @@
 ---
 pagetitle: "Diligent Services — Lighting & Control Integration"
-description: "Lighting, control, and entertainment systems for Southern California's finest homes, designed and programmed and maintained by one accountable team."
+description: "Diligent Services designs, installs, and programs lighting, AV, control, and networking for high-end residential and commercial spaces across California and Nevada. A DBA of Carmelita Enterprises Inc, CSLB 1132892."
 page-layout: full
 toc: false
 anchor-sections: false
 ---
 
 ::: {.hero}
-[Lighting & Control Integration · Southern California]{.hero-eyebrow}
+[Lighting & Control Integration · California & Nevada]{.hero-eyebrow}
 
-[Light. Control.<br>Effortless living.]{.hero-title}
+[Light. Control.<br>Effortless.]{.hero-title}
 
-[Diligent Services designs, programs, and maintains the lighting, control, and entertainment systems that make Southern California's finest homes feel effortless. One accountable team, from design through the years of support that follow.]{.hero-sub}
+[We design, install, and program lighting, audio/visual, control, and networking for high-end homes and commercial spaces across California and Nevada. Quiet to operate, considered in every detail, built to disappear into the room.]{.hero-sub}
 
-[Request a consultation](contact.qmd){.btn-cta} [See what we do](services.qmd){.btn-ghost}
+[Start a project](contact.qmd){.btn-cta} [See our capabilities](services.qmd){.btn-ghost}
 :::
 
 <hr class="rule">
@@ -21,7 +21,7 @@ anchor-sections: false
 ::: {.section}
 [What we do]{.section-kicker}
 
-[We don't sell boxes. We design systems: specified, programmed, and documented so the technology serves the home instead of the other way around.]{.section-lead}
+[Four disciplines, integrated as one system. We specify and program platforms such as Lutron, Savant, and Ketra, then make them work together so a residence, a retail floor, or a hospitality venue behaves as a single, calm whole.]{.section-lead}
 
 ::: {.pillars}
 ::: {.pillar}
@@ -29,28 +29,28 @@ anchor-sections: false
 
 ### Lighting & Tunable Light
 
-Layered scenes, motorized shades, and warm-to-cool tuning that shifts with the day. Lighting designed to read as architecture rather than gadgetry.
+Layered, dimmable, color-tunable lighting that flatters a room and follows the day. The same discipline serves a private residence, a retail boutique, or a hospitality floor.
 :::
 ::: {.pillar}
 [02]{.ix}
 
 ### Audio / Visual
 
-Reference-grade media rooms, distributed audio, and theaters tuned to the room they live in.
+Distributed audio and video that reads cleanly in living spaces and across commercial properties, with sources, displays, and acoustics resolved before a single wire is pulled.
 :::
 ::: {.pillar}
 [03]{.ix}
 
 ### Control & Automation
 
-One calm interface that unifies lighting, climate, shades, AV, and security. Simple enough for everyone in the house to use.
+One interface for light, shade, climate, and media, so a home or a venue responds to a single touch, a schedule, or a scene without anyone tending it.
 :::
 ::: {.pillar}
 [04]{.ix}
 
 ### Networking & Infrastructure
 
-Enterprise-grade Wi-Fi, structured wiring, and the quiet, reliable backbone every connected home actually runs on.
+The wired and wireless backbone every other system depends on: structured cabling, resilient networks, and clean racks sized for homes and commercial sites alike.
 :::
 :::
 :::
@@ -62,25 +62,71 @@ Enterprise-grade Wi-Fi, structured wiring, and the quiet, reliable backbone ever
 
 ::: {.why}
 ::: {.tile}
-### One accountable team
+### Resi-mercial range
 
-Design, programming, installation, and support under one roof, so nothing falls between trades.
+Luxury residences and commercial spaces, from active-adult communities in Northern California to retail and hospitality work across California and Nevada.
 :::
 ::: {.tile}
-### Built to be serviced
+### Family-run, since 2002
 
-Every system labeled, documented, and supportable. When something needs attention, we answer.
+Founded by Tony and Barbara Myers, run today by Sam and Pearl Myers. A small team that answers for its own work and earns the next project by referral.
 :::
 ::: {.tile}
-### We put our name on it
+### We specify and program
 
-A family operation that stands behind the work. Licensed in California, and around long after the install crew leaves.
+Not box-movers. We design the system, integrate the platforms, write the programming, and commission it so it holds up after we leave.
+:::
+::: {.tile}
+### Licensed in California
+
+Carmelita Enterprises Inc, CSLB 1132892. Accountable and documented from proposal through closeout.
 :::
 :::
+:::
+
+<hr class="rule">
+
+::: {.section}
+[Selected work]{.section-kicker}
+
+[A working portfolio across California and Nevada, from luxury residential to commercial and hospitality. We design, program, and stand behind lighting and control on platforms including Lutron, Savant, and Ketra.]{.section-lead}
+
+::: {.work}
+::: {.work-card}
+[Builder programs]{.cat}
+
+### A multi-year program across Northern California
+
+We run an ongoing, multi-home program for a national homebuilder's luxury active-adult communities in the greater Sacramento region, delivering repeatable lighting, shading, and network packages across dozens of homes with full change-order support.
+:::
+::: {.work-card}
+[Commercial & retail]{.cat}
+
+### Lighting control for a globally recognized brand
+
+We're the lighting-control specialist on luxury retail boutiques for a globally recognized brand, modernizing aging proprietary control to a current Lutron platform with custom-engraved keypads and scene control, on tight overnight windows that keep flagship stores trading.
+:::
+::: {.work-card}
+[Hospitality · in development]{.cat}
+
+### Modernizing lighting for hospitality & nightlife
+
+We migrate legacy panel-based dimming in hospitality and nightlife venues to a current Lutron HomeWorks platform with tunable, dynamic feature lighting and remote-supportable scene control, so a venue can refresh its look without re-pulling its existing infrastructure.
+:::
+::: {.work-card}
+[Our reference estate]{.cat}
+
+### The 22-zone home where we prove every approach
+
+Our own reference installation is a 22-zone residence where we run Savant control over Lutron lighting end to end, the home we use to prove and refine every lighting, shading, and control approach before we put it in a client's space.
+:::
+:::
+
+[Client names withheld by agreement. We're glad to walk you through relevant work on a call.]{.work-note}
 :::
 
 ::: {.closing}
 ## Let's design something quietly extraordinary.
 
-[Request a consultation](contact.qmd){.btn-cta}
+[Start a project](contact.qmd){.btn-cta}
 :::

--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# publish.sh — safe, rollback-able deploy for diligentservices.io
+#
+# Run this ON THE WEB SERVER (Hetzner), from inside the site repo:
+#   cd /var/www/diligentservices/diligentservices-quarto && ./publish.sh
+#
+# What it does, in order:
+#   1. Backs up the current live _site to _site.bak.<timestamp>
+#   2. Records the current git commit (so we can roll back to it)
+#   3. Fast-forward pulls origin/main
+#   4. Activates the Python venv (required, or computational blog posts fail)
+#   5. Renders the site
+# If ANY step fails, it automatically restores the previous commit AND the
+# previous _site, so the live site is never left half-broken.
+#
+set -euo pipefail
+cd "$(dirname "$0")"
+
+STAMP="$(date +%Y%m%d-%H%M%S)"
+PREV_COMMIT="$(git rev-parse HEAD)"
+BACKUP="_site.bak.$STAMP"
+
+echo "==> Current live commit: $PREV_COMMIT"
+if [ -d _site ]; then
+  echo "==> Backing up live _site -> $BACKUP"
+  cp -a _site "$BACKUP"
+fi
+
+restore() {
+  echo "!! Publish FAILED. Restoring the previous version."
+  git reset --hard "$PREV_COMMIT" || true
+  if [ -d "$BACKUP" ]; then rm -rf _site && mv "$BACKUP" _site; fi
+  echo "!! Live site restored to $PREV_COMMIT. Nothing broken is live."
+  exit 1
+}
+trap restore ERR
+
+echo "==> Pulling origin/main (fast-forward only)"
+git fetch origin
+git merge --ff-only origin/main
+
+echo "==> Activating venv"
+# shellcheck disable=SC1091
+source .venv/bin/activate
+
+echo "==> Rendering"
+quarto render
+
+trap - ERR
+echo ""
+echo "==> Published successfully."
+echo "    Previous version was: $PREV_COMMIT"
+echo "    Roll back any time with:  ./rollback.sh $PREV_COMMIT"
+echo "    (A copy of the old site is also kept at: $BACKUP)"

--- a/rollback.sh
+++ b/rollback.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# rollback.sh — revert the LIVE site to a previous version and re-render.
+#
+# Run this ON THE WEB SERVER (Hetzner), from inside the site repo:
+#   ./rollback.sh <git-commit-sha>
+#
+# Find a commit to roll back to with:  git log --oneline
+# (publish.sh also prints the previous commit each time it runs.)
+#
+set -euo pipefail
+cd "$(dirname "$0")"
+
+TARGET="${1:-}"
+if [ -z "$TARGET" ]; then
+  echo "Usage: ./rollback.sh <commit-sha>"
+  echo "Recent commits:"
+  git --no-pager log --oneline -10
+  exit 1
+fi
+
+echo "==> Rolling the live site back to $TARGET"
+git checkout "$TARGET"
+# shellcheck disable=SC1091
+source .venv/bin/activate
+quarto render
+echo ""
+echo "==> Rolled back and re-rendered at $TARGET."
+echo "    You are now in 'detached HEAD'. To return to the latest published"
+echo "    version when you're ready:  git checkout main && ./publish.sh"

--- a/services.qmd
+++ b/services.qmd
@@ -1,37 +1,37 @@
 ---
 title: "Services"
 pagetitle: "Services — Diligent Services"
-description: "Lighting, audio/visual, control, and the systems behind them, designed and programmed and maintained for high-end Southern California homes."
+description: "Lighting, audio/visual, control, and the systems behind them, designed and programmed for high-end residential and commercial spaces across California and Nevada."
 toc: true
 toc-title: "On this page"
 ---
 
-We design, program, and maintain the systems a high-end home runs on. One team carries each project from design through commissioning and the years of service that follow, so the technology stays out of the way and the house stays effortless.
+We design, install, and program integrated lighting and control systems for high-end residential and commercial spaces across California and Nevada, from private estates and luxury active-adult communities to retail boutiques and hospitality interiors. The work is the same discipline at every scale: get the light, the sound, the control, and the network right, then make them disappear into a space that simply works.
 
 ## Lighting & Tunable Light
 
-Lighting is the first thing you feel in a room and the last thing you should have to think about. We design layered lighting and motorized shades around how a home is actually lived in: warm and quiet at night, bright and clean for work, and tuned to shift with the day. Scenes are programmed so a single press sets the whole room, and so the system reads as part of the architecture rather than a wall of switches.
+Architectural lighting and full-spectrum tunable light, designed and programmed so a room reads the way it should at every hour. We specify and commission fixtures and lighting control for residences, retail, and hospitality, with color and intensity that flatter a living space, a gallery wall, or a display case, on schedules and scenes that hold steady long after we leave.
 
 ## Audio / Visual
 
-Reference-grade media rooms, distributed audio throughout the home, and dedicated theaters tuned to the room they live in. We handle the displays, the sound, the sources, and the wiring behind them, and we program the control so the family can actually use what they paid for.
+Distributed audio, home theater, and display systems for homes and commercial interiors. We handle the room acoustics, the screens, and the sources, then tie them into the control system so playback is one clean gesture, whether that's a private screening room, whole-property music, or background audio and signage across a commercial floor.
 
 ## Control & Automation
 
-One calm interface for lighting, climate, shades, audio/visual, and security. We program automation that fits the household, not a generic template, so the right things happen at the right time and everything stays simple for whoever is holding the remote or the phone. The goal is a home that anyone in the family can run without a manual.
+One coherent control layer over lighting, shades, climate, audio, and video. We program the platforms that run the room, on a keypad, a touchscreen, or a phone, so a single press sets a scene, opens the house for the morning, or readies a venue for service. The goal is fewer decisions for the client, not more screens.
 
 ## Networking, Security & Infrastructure
 
-Everything above depends on a network that does not flinch. We design and install enterprise-grade Wi-Fi, structured wiring, cameras, and the structured backbone a connected home needs, built and labeled so it can be supported for years rather than rewired every time something changes.
+The wired and wireless backbone everything else depends on: structured cabling, managed networks, surveillance, and access control sized for the property. We build infrastructure that holds up under a full estate or a busy commercial floor, with the headroom and reliability a luxury install needs and the documentation to maintain it.
 
 ## Service & Support
 
-We treat the install as the start of a long relationship. Every system we deliver is documented and labeled, and we stay reachable when something needs attention. For a high-end home, dependable support is the part of the work that matters most.
+Systems we install are systems we stand behind. We offer ongoing service, monitoring, and updates for the lighting and control we deliver, resolving issues, adapting scenes as a space evolves, and keeping firmware and programming current. For multi-property and commercial clients, that means a single team that already knows the system.
 
 ::: {.platforms}
-**Platforms we work with.** We design and program on the platforms that define this category, including **Savant** and **Lutron**, chosen per project rather than per contract. The right system is the one that fits the home, not the one we are obligated to sell.
+**Platforms we work with.** We design around the platforms that hold up in luxury work and program them ourselves: **Savant** for whole-property control, **Lutron** for lighting control and shading, and **Ketra** as a tunable-light platform. We specify, install, and commission these systems. What we offer is the design and programming, not a dealer or certification badge.
 :::
 
 ---
 
-Ready to talk? [Request a consultation](contact.qmd){.btn-cta}
+Ready to talk? [Start a project](contact.qmd){.btn-cta}

--- a/services.qmd
+++ b/services.qmd
@@ -1,0 +1,37 @@
+---
+title: "Services"
+pagetitle: "Services — Diligent Services"
+description: "Lighting, audio/visual, control, and the systems behind them, designed and programmed and maintained for high-end Southern California homes."
+toc: true
+toc-title: "On this page"
+---
+
+We design, program, and maintain the systems a high-end home runs on. One team carries each project from design through commissioning and the years of service that follow, so the technology stays out of the way and the house stays effortless.
+
+## Lighting & Tunable Light
+
+Lighting is the first thing you feel in a room and the last thing you should have to think about. We design layered lighting and motorized shades around how a home is actually lived in: warm and quiet at night, bright and clean for work, and tuned to shift with the day. Scenes are programmed so a single press sets the whole room, and so the system reads as part of the architecture rather than a wall of switches.
+
+## Audio / Visual
+
+Reference-grade media rooms, distributed audio throughout the home, and dedicated theaters tuned to the room they live in. We handle the displays, the sound, the sources, and the wiring behind them, and we program the control so the family can actually use what they paid for.
+
+## Control & Automation
+
+One calm interface for lighting, climate, shades, audio/visual, and security. We program automation that fits the household, not a generic template, so the right things happen at the right time and everything stays simple for whoever is holding the remote or the phone. The goal is a home that anyone in the family can run without a manual.
+
+## Networking, Security & Infrastructure
+
+Everything above depends on a network that does not flinch. We design and install enterprise-grade Wi-Fi, structured wiring, cameras, and the structured backbone a connected home needs, built and labeled so it can be supported for years rather than rewired every time something changes.
+
+## Service & Support
+
+We treat the install as the start of a long relationship. Every system we deliver is documented and labeled, and we stay reachable when something needs attention. For a high-end home, dependable support is the part of the work that matters most.
+
+::: {.platforms}
+**Platforms we work with.** We design and program on the platforms that define this category, including **Savant** and **Lutron**, chosen per project rather than per contract. The right system is the one that fits the home, not the one we are obligated to sell.
+:::
+
+---
+
+Ready to talk? [Request a consultation](contact.qmd){.btn-cta}

--- a/services.qmd
+++ b/services.qmd
@@ -1,37 +1,37 @@
 ---
 title: "Services"
 pagetitle: "Services — Diligent Services"
-description: "Lighting, audio/visual, control, and the systems behind them, designed and programmed for high-end residential and commercial spaces across California and Nevada."
+description: "Lighting, audio/visual, control, and the systems behind them, designed and programmed for high-end homes and commercial spaces."
 toc: true
 toc-title: "On this page"
 ---
 
-We design, install, and program integrated lighting and control systems for high-end residential and commercial spaces across California and Nevada, from private estates and luxury active-adult communities to retail boutiques and hospitality interiors. The work is the same discipline at every scale: get the light, the sound, the control, and the network right, then make them disappear into a space that simply works.
+We design, install, and program integrated lighting and control systems for high-end homes and commercial spaces. The work is the same discipline at every scale: get the light, the sound, the control, and the network right, then make them disappear into a space that simply works.
 
-## Lighting & Tunable Light
+## Lighting and Tunable Light
 
-Architectural lighting and full-spectrum tunable light, designed and programmed so a room reads the way it should at every hour. We specify and commission fixtures and lighting control for residences, retail, and hospitality, with color and intensity that flatter a living space, a gallery wall, or a display case, on schedules and scenes that hold steady long after we leave.
+Architectural lighting and full-spectrum tunable light, designed and programmed so a room reads the way it should at every hour. We specify and commission fixtures and lighting control, with color and intensity on schedules and scenes that hold steady long after we leave.
 
-## Audio / Visual
+## Audio and Visual
 
-Distributed audio, home theater, and display systems for homes and commercial interiors. We handle the room acoustics, the screens, and the sources, then tie them into the control system so playback is one clean gesture, whether that's a private screening room, whole-property music, or background audio and signage across a commercial floor.
+Distributed audio, home theater, and display systems. We handle the room acoustics, the screens, and the sources, then tie them into the control system so playback is one clean gesture.
 
-## Control & Automation
+## Control and Automation
 
-One coherent control layer over lighting, shades, climate, audio, and video. We program the platforms that run the room, on a keypad, a touchscreen, or a phone, so a single press sets a scene, opens the house for the morning, or readies a venue for service. The goal is fewer decisions for the client, not more screens.
+One coherent control layer over lighting, shades, climate, audio, and video. We program the platforms that run the room, on a keypad, a touchscreen, or a phone, so a single press sets a scene. The goal is fewer decisions for the client, not more screens.
 
-## Networking, Security & Infrastructure
+## Networking, Security, and Infrastructure
 
-The wired and wireless backbone everything else depends on: structured cabling, managed networks, surveillance, and access control sized for the property. We build infrastructure that holds up under a full estate or a busy commercial floor, with the headroom and reliability a luxury install needs and the documentation to maintain it.
+The wired and wireless backbone everything else depends on: structured cabling, managed networks, surveillance, and access control sized for the property, with the documentation to maintain it.
 
-## Service & Support
+## Service and Support
 
-Systems we install are systems we stand behind. We offer ongoing service, monitoring, and updates for the lighting and control we deliver, resolving issues, adapting scenes as a space evolves, and keeping firmware and programming current. For multi-property and commercial clients, that means a single team that already knows the system.
+Systems we install are systems we stand behind. We offer ongoing service, monitoring, and updates for the lighting and control we deliver, resolving issues and keeping programming current as a space evolves.
 
-::: {.platforms}
-**Platforms we work with.** We design around the platforms that hold up in luxury work and program them ourselves: **Savant** for whole-property control, **Lutron** for lighting control and shading, and **Ketra** as a tunable-light platform. We specify, install, and commission these systems. What we offer is the design and programming, not a dealer or certification badge.
-:::
+### Platforms we work with
+
+We design around proven professional platforms and program them ourselves, including Lutron for lighting control and shading and Savant for whole-property control. What we offer is the design and the programming, not a sales counter.
 
 ---
 
-Ready to talk? [Start a project](contact.qmd){.btn-cta}
+Ready to talk? [Start a project](contact.qmd){.btn .btn-primary}

--- a/styles/custom.scss
+++ b/styles/custom.scss
@@ -1,216 +1,51 @@
 /*-- scss:defaults --*/
 
-// ── Diligent Services — "quiet luxury" palette ───────────────────
-// Premium comes from restraint and whitespace, not effects.
-$ds-ink:     #0E0F12;   // deepest canvas
-$ds-ink-2:   #14161A;   // raised panels / alternate sections
-$ds-paper:   #F4F1EA;   // warm off-white text (not pure white)
-$ds-muted:   #B9B5AC;   // secondary text
-$ds-brass:   #C9A24B;   // the single warm metallic accent (kept under ~5% of any view)
-$ds-brass-2: #D9B868;   // brass hover / active
-$ds-hair:    rgba(244, 241, 234, 0.12);
+// ───────────────────────────────────────────────────────────────
+// Diligent Services — light & clean theme.
+// To retune the look, change the values below. That's all most edits need.
+//   - Colors are hex codes (the # values). Pick new ones and re-render.
+//   - Fonts are Google Font names; to change them also update the <link>
+//     in _quarto.yml (see EDITING.md).
+// ───────────────────────────────────────────────────────────────
 
-// ── Bootstrap / Quarto variable overrides ───────────────────────
-$body-bg:          $ds-ink;
-$body-color:       $ds-paper;
+$ds-cream:   #FBF9F4;  // page background (warm off-white)
+$ds-ink:     #23201A;  // body + heading text (warm near-black)
+$ds-muted:   #6B655B;  // secondary / lighter text
+$ds-brass:   #9A6B1E;  // the one warm accent (buttons, active nav, rules)
+$ds-link:    #7E5615;  // link text (a touch darker so it stays readable)
+$ds-hair:    #E7E1D6;  // hairlines / borders
+
+// Map our palette onto the theme. Usually no need to touch these.
+$body-bg:          $ds-cream;
+$body-color:       $ds-ink;
 $primary:          $ds-brass;
-$link-color:       $ds-brass;
-$link-hover-color: $ds-brass-2;
+$link-color:       $ds-link;
+$link-hover-color: $ds-brass;
 $border-color:     $ds-hair;
 
-$navbar-bg: $ds-ink;
-$navbar-fg: $ds-paper;
+$navbar-bg: $ds-cream;
+$navbar-fg: $ds-ink;
 $navbar-hl: $ds-brass;
-
-$footer-bg: #0B0C0E;
+$footer-bg: #F3EFE7;
 $footer-fg: $ds-muted;
 
-// ── Typography: editorial serif display + clean grotesque body ──
-$font-family-sans-serif: 'Inter', system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+$font-family-sans-serif: 'Inter', system-ui, -apple-system, "Segoe UI", sans-serif;
 $headings-font-family:   'Fraunces', Georgia, "Times New Roman", serif;
 $headings-font-weight:   600;
-$headings-color:         $ds-paper;
+$headings-color:         $ds-ink;
 $body-line-height:       1.65;
-
-$h1-font-size: 2.6rem;
-$h2-font-size: 1.9rem;
-$h3-font-size: 1.3rem;
-$h4-font-size: 1.1rem;
 
 /*-- scss:rules --*/
 
-body {
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-}
+body { -webkit-font-smoothing: antialiased; }
+h1, h2, h3 { letter-spacing: -0.01em; }
 
-h1, h2, h3 { letter-spacing: -0.01em; line-height: 1.15; }
+// Make the homepage title (front-matter "title:") read as a hero.
+.quarto-title-block .title { font-size: clamp(2.2rem, 5vw, 3.4rem); line-height: 1.08; }
+.quarto-title-block .subtitle { color: $ds-muted; font-weight: 400; }
 
-a { text-decoration: none; }
-a:hover { color: $ds-brass-2; }
-
-// ── Buttons ─────────────────────────────────────────────────────
-.btn-cta, .btn-ghost {
-  display: inline-block;
-  font-family: $font-family-sans-serif;
-  font-weight: 600;
-  font-size: 0.95rem;
-  letter-spacing: 0.02em;
-  padding: 0.85rem 1.7rem;
-  border-radius: 2px;
-  transition: all 0.25s ease;
-  margin: 0.35rem 0.55rem 0.35rem 0;
-}
-.btn-cta {
-  background: $ds-brass;
-  color: $ds-ink !important;
-  border: 1px solid $ds-brass;
-}
-.btn-cta:hover { background: $ds-brass-2; border-color: $ds-brass-2; color: $ds-ink !important; }
-.btn-ghost {
-  background: transparent;
-  color: $ds-paper !important;
-  border: 1px solid $ds-hair;
-}
-.btn-ghost:hover { border-color: $ds-brass; color: $ds-brass !important; }
-
-// ── Hero ────────────────────────────────────────────────────────
-.hero {
-  text-align: center;
-  max-width: 880px;
-  margin: 0 auto;
-  padding: 6rem 1.5rem 4.5rem;
-}
-.hero-eyebrow {
-  display: block;
-  font-family: $font-family-sans-serif;
-  text-transform: uppercase;
-  letter-spacing: 0.22em;
-  font-size: 0.72rem;
-  color: $ds-brass;
-  margin-bottom: 1.6rem;
-}
-.hero-title {
-  display: block;
-  font-family: $headings-font-family;
-  font-weight: 500;
-  font-size: clamp(2.6rem, 6vw, 4.4rem);
-  line-height: 1.04;
-  color: $ds-paper;
-  margin: 0 0 1.5rem;
-}
-.hero-sub {
-  display: block;
-  font-size: 1.15rem;
-  line-height: 1.6;
-  color: $ds-muted;
-  max-width: 620px;
-  margin: 0 auto 2.4rem;
-}
-
-// ── Section frame ───────────────────────────────────────────────
-.section {
-  max-width: 1080px;
-  margin: 0 auto;
-  padding: 4rem 1.5rem;
-}
-.section-kicker {
-  display: block;
-  text-transform: uppercase;
-  letter-spacing: 0.2em;
-  font-size: 0.72rem;
-  color: $ds-brass;
-  font-family: $font-family-sans-serif;
-  margin-bottom: 0.9rem;
-}
-.section-lead {
-  display: block;
-  font-family: $headings-font-family;
-  font-weight: 400;
-  font-size: clamp(1.55rem, 3vw, 2.15rem);
-  color: $ds-paper;
-  max-width: 760px;
-  margin: 0 0 2.6rem;
-  line-height: 1.25;
-}
-hr.rule { height: 1px; background: $ds-hair; border: 0; margin: 0; opacity: 1; }
-
-// ── Capability tiles ────────────────────────────────────────────
-.pillars, .why {
-  display: grid;
-  gap: 1.4rem;
-  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
-}
-.pillar, .tile {
-  background: $ds-ink-2;
-  border: 1px solid $ds-hair;
-  border-radius: 3px;
-  padding: 1.8rem 1.6rem;
-}
-.pillar h3, .tile h3 { font-size: 1.18rem; margin: 0 0 0.6rem; color: $ds-paper; }
-.pillar p, .tile p { color: $ds-muted; font-size: 0.97rem; margin: 0; }
-.pillar .ix {
-  display: block;
-  color: $ds-brass;
-  font-size: 0.78rem;
-  letter-spacing: 0.18em;
-  margin-bottom: 0.9rem;
-  font-family: $font-family-sans-serif;
-}
-
-// ── Selected work band ──────────────────────────────────────────
-.work {
-  display: grid;
-  gap: 1.4rem;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-}
-.work-card {
-  background: $ds-ink-2;
-  border: 1px solid $ds-hair;
-  border-radius: 3px;
-  padding: 1.8rem 1.6rem;
-}
-.work-card .cat {
-  display: block;
-  color: $ds-brass;
-  font-size: 0.72rem;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  font-family: $font-family-sans-serif;
-  margin-bottom: 0.9rem;
-}
-.work-card h3 { font-size: 1.12rem; margin: 0 0 0.6rem; color: $ds-paper; }
-.work-card p { color: $ds-muted; font-size: 0.96rem; margin: 0; }
-.work-note {
-  display: block;
-  color: $ds-muted;
-  font-size: 0.85rem;
-  font-style: italic;
-  margin-top: 1.6rem;
-}
-
-// ── Closing CTA ─────────────────────────────────────────────────
-.closing {
-  text-align: center;
-  padding: 5rem 1.5rem 6rem;
-  border-top: 1px solid $ds-hair;
-  margin-top: 2rem;
-}
-.closing h2 { font-size: clamp(1.8rem, 4vw, 2.8rem); margin-bottom: 1.6rem; }
-
-// ── Platforms note ──────────────────────────────────────────────
-.platforms { color: $ds-muted; font-size: 0.96rem; }
-.platforms strong { color: $ds-paper; font-weight: 600; }
-
-// ── Navbar + footer polish ──────────────────────────────────────
 .navbar { border-bottom: 1px solid $ds-hair; }
-.navbar-brand { font-family: $headings-font-family; font-weight: 600; letter-spacing: 0.01em; }
-.navbar .nav-link { letter-spacing: 0.02em; }
-.nav-footer { border-top: 1px solid $ds-hair; font-size: 0.85rem; }
-.nav-footer a { color: $ds-muted; }
-.nav-footer a:hover { color: $ds-brass; }
+.navbar-brand { font-family: $headings-font-family; font-weight: 600; }
 
-// Respect reduced-motion globally
-@media (prefers-reduced-motion: reduce) {
-  * { transition: none !important; animation: none !important; }
-}
+// A little breathing room between stacked buttons on the homepage.
+.btn { margin: 0.25rem 0.4rem 0.25rem 0; }

--- a/styles/custom.scss
+++ b/styles/custom.scss
@@ -158,6 +158,37 @@ hr.rule { height: 1px; background: $ds-hair; border: 0; margin: 0; opacity: 1; }
   font-family: $font-family-sans-serif;
 }
 
+// ── Selected work band ──────────────────────────────────────────
+.work {
+  display: grid;
+  gap: 1.4rem;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+}
+.work-card {
+  background: $ds-ink-2;
+  border: 1px solid $ds-hair;
+  border-radius: 3px;
+  padding: 1.8rem 1.6rem;
+}
+.work-card .cat {
+  display: block;
+  color: $ds-brass;
+  font-size: 0.72rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  font-family: $font-family-sans-serif;
+  margin-bottom: 0.9rem;
+}
+.work-card h3 { font-size: 1.12rem; margin: 0 0 0.6rem; color: $ds-paper; }
+.work-card p { color: $ds-muted; font-size: 0.96rem; margin: 0; }
+.work-note {
+  display: block;
+  color: $ds-muted;
+  font-size: 0.85rem;
+  font-style: italic;
+  margin-top: 1.6rem;
+}
+
 // ── Closing CTA ─────────────────────────────────────────────────
 .closing {
   text-align: center;

--- a/styles/custom.scss
+++ b/styles/custom.scss
@@ -1,109 +1,185 @@
 /*-- scss:defaults --*/
-$footer-bg: #343a40;
-$footer-fg: #ffffff;
 
-$navbar-bg: #f46828; /* Construction orange */
-$navbar-fg: #ffffff;
-$body-bg: #f8f9fa; /* Light grey background */
-$body-color: #333333;
+// ── Diligent Services — "quiet luxury" palette ───────────────────
+// Premium comes from restraint and whitespace, not effects.
+$ds-ink:     #0E0F12;   // deepest canvas
+$ds-ink-2:   #14161A;   // raised panels / alternate sections
+$ds-paper:   #F4F1EA;   // warm off-white text (not pure white)
+$ds-muted:   #B9B5AC;   // secondary text
+$ds-brass:   #C9A24B;   // the single warm metallic accent (kept under ~5% of any view)
+$ds-brass-2: #D9B868;   // brass hover / active
+$ds-hair:    rgba(244, 241, 234, 0.12);
 
-/* Font Sizes */
-$h1-font-size: 1.5rem;
-$h2-font-size: 1.25rem;
-$h3-font-size: 1rem;
-$h4-font-size: 0.875rem;
+// ── Bootstrap / Quarto variable overrides ───────────────────────
+$body-bg:          $ds-ink;
+$body-color:       $ds-paper;
+$primary:          $ds-brass;
+$link-color:       $ds-brass;
+$link-hover-color: $ds-brass-2;
+$border-color:     $ds-hair;
 
-/* Link Colors */
-$link-color: #5b92e5; /* Pantone blue */
-$link-hover-color: #2c5aa0; /* Darker blue for hover */
+$navbar-bg: $ds-ink;
+$navbar-fg: $ds-paper;
+$navbar-hl: $ds-brass;
+
+$footer-bg: #0B0C0E;
+$footer-fg: $ds-muted;
+
+// ── Typography: editorial serif display + clean grotesque body ──
+$font-family-sans-serif: 'Inter', system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+$headings-font-family:   'Fraunces', Georgia, "Times New Roman", serif;
+$headings-font-weight:   600;
+$headings-color:         $ds-paper;
+$body-line-height:       1.65;
+
+$h1-font-size: 2.6rem;
+$h2-font-size: 1.9rem;
+$h3-font-size: 1.3rem;
+$h4-font-size: 1.1rem;
 
 /*-- scss:rules --*/
+
 body {
-  background-color: $body-bg;
-  color: $body-color;
-  font-family: 'Arial', sans-serif;
-  font-size: 1rem;
-  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }
 
-h1, h2, h3, h4, h5, h6 {
-  color: $navbar-bg;
-  margin-bottom: 0.5em;
-}
+h1, h2, h3 { letter-spacing: -0.01em; line-height: 1.15; }
 
-a {
-  color: $link-color;
-  text-decoration: none;
-}
+a { text-decoration: none; }
+a:hover { color: $ds-brass-2; }
 
-a:hover {
-  color: $link-hover-color;
-  text-decoration: underline;
+// ── Buttons ─────────────────────────────────────────────────────
+.btn-cta, .btn-ghost {
+  display: inline-block;
+  font-family: $font-family-sans-serif;
+  font-weight: 600;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+  padding: 0.85rem 1.7rem;
+  border-radius: 2px;
+  transition: all 0.25s ease;
+  margin: 0.35rem 0.55rem 0.35rem 0;
 }
+.btn-cta {
+  background: $ds-brass;
+  color: $ds-ink !important;
+  border: 1px solid $ds-brass;
+}
+.btn-cta:hover { background: $ds-brass-2; border-color: $ds-brass-2; color: $ds-ink !important; }
+.btn-ghost {
+  background: transparent;
+  color: $ds-paper !important;
+  border: 1px solid $ds-hair;
+}
+.btn-ghost:hover { border-color: $ds-brass; color: $ds-brass !important; }
 
-footer {
-  background-color: $footer-bg;
-  color: $footer-fg;
-  padding: 20px 0;
+// ── Hero ────────────────────────────────────────────────────────
+.hero {
   text-align: center;
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 6rem 1.5rem 4.5rem;
+}
+.hero-eyebrow {
+  display: block;
+  font-family: $font-family-sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  font-size: 0.72rem;
+  color: $ds-brass;
+  margin-bottom: 1.6rem;
+}
+.hero-title {
+  display: block;
+  font-family: $headings-font-family;
+  font-weight: 500;
+  font-size: clamp(2.6rem, 6vw, 4.4rem);
+  line-height: 1.04;
+  color: $ds-paper;
+  margin: 0 0 1.5rem;
+}
+.hero-sub {
+  display: block;
+  font-size: 1.15rem;
+  line-height: 1.6;
+  color: $ds-muted;
+  max-width: 620px;
+  margin: 0 auto 2.4rem;
 }
 
-.footer-content {
-  display: flex;
-  justify-content: space-around;
-  flex-wrap: wrap;
-  padding: 20px;
+// ── Section frame ───────────────────────────────────────────────
+.section {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 4rem 1.5rem;
+}
+.section-kicker {
+  display: block;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.72rem;
+  color: $ds-brass;
+  font-family: $font-family-sans-serif;
+  margin-bottom: 0.9rem;
+}
+.section-lead {
+  display: block;
+  font-family: $headings-font-family;
+  font-weight: 400;
+  font-size: clamp(1.55rem, 3vw, 2.15rem);
+  color: $ds-paper;
+  max-width: 760px;
+  margin: 0 0 2.6rem;
+  line-height: 1.25;
+}
+hr.rule { height: 1px; background: $ds-hair; border: 0; margin: 0; opacity: 1; }
+
+// ── Capability tiles ────────────────────────────────────────────
+.pillars, .why {
+  display: grid;
+  gap: 1.4rem;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+}
+.pillar, .tile {
+  background: $ds-ink-2;
+  border: 1px solid $ds-hair;
+  border-radius: 3px;
+  padding: 1.8rem 1.6rem;
+}
+.pillar h3, .tile h3 { font-size: 1.18rem; margin: 0 0 0.6rem; color: $ds-paper; }
+.pillar p, .tile p { color: $ds-muted; font-size: 0.97rem; margin: 0; }
+.pillar .ix {
+  display: block;
+  color: $ds-brass;
+  font-size: 0.78rem;
+  letter-spacing: 0.18em;
+  margin-bottom: 0.9rem;
+  font-family: $font-family-sans-serif;
 }
 
-.footer-section {
-  flex: 1;
-  min-width: 200px;
-  margin: 10px;
+// ── Closing CTA ─────────────────────────────────────────────────
+.closing {
+  text-align: center;
+  padding: 5rem 1.5rem 6rem;
+  border-top: 1px solid $ds-hair;
+  margin-top: 2rem;
 }
+.closing h2 { font-size: clamp(1.8rem, 4vw, 2.8rem); margin-bottom: 1.6rem; }
 
-.footer-section h2 {
-  color: $footer-fg;
-  margin-bottom: 10px;
-}
+// ── Platforms note ──────────────────────────────────────────────
+.platforms { color: $ds-muted; font-size: 0.96rem; }
+.platforms strong { color: $ds-paper; font-weight: 600; }
 
-.footer-section p, .footer-section ul {
-  margin: 0;
-}
+// ── Navbar + footer polish ──────────────────────────────────────
+.navbar { border-bottom: 1px solid $ds-hair; }
+.navbar-brand { font-family: $headings-font-family; font-weight: 600; letter-spacing: 0.01em; }
+.navbar .nav-link { letter-spacing: 0.02em; }
+.nav-footer { border-top: 1px solid $ds-hair; font-size: 0.85rem; }
+.nav-footer a { color: $ds-muted; }
+.nav-footer a:hover { color: $ds-brass; }
 
-.footer-section ul {
-  list-style: none;
-  padding: 0;
-}
-
-.footer-section ul li {
-  margin-bottom: 5px;
-}
-
-.footer-section ul li a {
-  color: $footer-fg;
-  text-decoration: none;
-}
-
-.footer-section ul li a:hover {
-  text-decoration: underline;
-}
-
-.footer-bottom {
-  border-top: 1px solid lighten($footer-fg, 10%);
-  padding-top: 10px;
-  margin-top: 20px;
-}
-
-.footer-bottom p {
-  margin: 0;
-}
-
-.footer-socials a {
-  color: $footer-fg;
-  margin: 0 10px;
-  font-size: 1.2em;
-}
-
-.footer-socials a:hover {
-  color: lighten($footer-fg, 20%);
+// Respect reduced-motion globally
+@media (prefers-reduced-motion: reduce) {
+  * { transition: none !important; animation: none !important; }
 }


### PR DESCRIPTION
## What this does

Kills the stale **"general contractor / remodeler"** positioning on the marketing pages and implements the **credential-neutral** direction from `docs/WEBSITE-VISION.md`: luxury-residential **lighting & control integration** — *"Light. Control. Effortless living."*

Everything here is **audit-independent** — no certification/dealer badges, no case-study claims, no unverified facts. Review-gated: **nothing is deployed**; this is for your review.

### Pages
- **`index.qmd`** — new hero (`Light. Control. Effortless living.`) + 4 credential-neutral capability pillars (Lighting & Tunable Light / Audio-Visual / Control & Automation / Networking) + a why-us band + one consultation CTA. No brand badges, no "20 years of general contracting."
- **`services.qmd` (new)** — one page with deep-linkable sections. Includes a deliberately conservative *"Platforms we work with"* note naming **Savant + Lutron only** (both evidenced by Casa Carmelita), framed as platforms we **specify and program**, explicitly **not** dealer/authorized/certified badges. Say the word and I pull or expand it after the cert audit.
- **`about.qmd`** — reframes the category from "general contracting / interior remodeling" to **family-run systems integrator**, while keeping the Myers heritage, Colossians 3:23, **CSLB 1132892**, and the **DBA legal line** verbatim. The contractor's-license heritage is kept as a *strength* (systems specified to work with the house).
- **`contact.qmd`** — consultation-first copy. Email/phone/service-area **unchanged** (`info@`, (424) 448-5200).

### Look & nav
- **`styles/custom.scss`** — "quiet luxury" dark theme: charcoal canvas (`#0E0F12`), warm off-white text (`#F4F1EA`), one brass accent (`#C9A24B`, kept <5% of any view), editorial serif display (**Fraunces**) + clean body (**Inter**). WCAG-AA contrast (brass on charcoal ≈ 7:1); `prefers-reduced-motion` honored.
- **`_quarto.yml`** — nav adds **Services** (Home · Services · About · Blog · Contact · Support); footer keeps the **verbatim DBA line**; site description rewritten; Google Fonts wired.

## Decisions for you
1. **Dark theme is site-wide → it also restyles the blog.** It reads well (serif headings, brass links, legible code) but it changes your blog's look. Keep site-wide, or scope the dark register to marketing pages only and keep the blog lighter?
2. **IA:** I kept **Blog** in nav (you value it) and **deferred `/work`** (case studies are audit-gated) and `/privacy` (optional, no form yet). The vision's 7-page IA otherwise.
3. **Platform naming** (Savant/Lutron on Services) — keep conservative, expand after cert audit, or remove for now?
4. **G611:** authorship disclosure stays on `/support` (unchanged `_g611.qmd`). Want it more prominent (footer link / About)?

## Deferred — gated on your factual audit (Section 0 of the vision)
- `/work` case studies, manufacturer **certification/dealer badges**, and **builder-program (Taylor Morrison / Esplanade)** naming. None of these are in this PR.

## Audit questions to unlock the next phase
1. **Certs actually held** — exact Lutron tier? Ketra cert + the required showroom? Savant/Crestron dealer status? CEDIA/HTA? *(Only verified badges go up.)*
2. **Deliverable + permissioned projects** — which are delivered (not proposals) **and** client-OK to name? Can we name "Taylor Morrison — Esplanade at Madeira Ranch"? *(Fluxx = proposal, off. Casa Carmelita = your home, "our reference installation" only.)*
3. **Photography** — real permissioned install photos, or commission a Casa Carmelita shoot before a photo-led hero?
4. **Phone / lead routing / support@ alias** — public number ok in footer? Where do consultation requests land + SLA? Use `support@` aliased to you?

## Preview
Rendered locally with Quarto (build clean on all pages). Screenshots in the Sam–Jane DM.