### PR TITLE
blog: link Mitsubishi Part 2 to the public minisplit-local-public repo

### DIFF
--- a/blog/Local-First-Control-For-Mitsubishi-Minisplit-Part-2.qmd
+++ b/blog/Local-First-Control-For-Mitsubishi-Minisplit-Part-2.qmd
@@ -285,5 +285,8 @@ Loose ends:
 - **Push instead of poll.** The modules speak MQTT; moving from polling to
   event-driven state is the obvious next upgrade.
 
-The code — library, CLI, bridge, and the reverse-engineered API notes — is in
-the `minisplit-local` repo.
+The code — library, CLI, bridge, and the reverse-engineered API notes — is open
+source on GitHub:
+[**samstevenm/minisplit-local-public**](https://github.com/samstevenm/minisplit-local-public).
+Standard-library Python, MIT-licensed. Clone it, drop in your own `units.yaml`,
+and pick your front end.


### PR DESCRIPTION
The Mitsubishi mini-split **Part 2** post closed by mentioning "the \`minisplit-local\` repo" as plain text, with no link. This adds the link.

- Points to the already-public, sanitized mirror: **[samstevenm/minisplit-local-public](https://github.com/samstevenm/minisplit-local-public)** (MIT, standard-library Python).
- The private \`minisplit-local\` stays private on purpose — its full history holds the real, un-sanitized `units.yaml`. The `-public` mirror is a single squashed, depersonalized commit (example config only, placeholder MACs/IPs).
- **Secret-audited clean** by two independent passes (a grep sweep + an adversarial reviewer): no credentials, no owner/estate identity, only the LAN examples already shown in the post itself.

One-line content change; rendered locally to confirm the link resolves. Review-gated, not deployed.