### PR TITLE
Critical pass: remove "effortless", swap to Spectral, restore the Docs page, fix correctness

### DIFF
--- a/README_.qmd
+++ b/README_.qmd
@@ -1,214 +1,56 @@
 ---
-title: "README.qmd"
+title: "Docs"
+pagetitle: "Docs"
 format:
   html:
     toc: true
 ---
 
-### Diligent Services Quarto Project
+## This website is open source
 
-This is the source for **diligentservices.io**, a static site built with [Quarto](https://quarto.org/). It is designed to be **hand-maintained**: every page is plain Markdown, and a step-by-step, non-technical guide lives in **[EDITING.md](EDITING.md)** — how to edit pages, change the menu / footer / contact details, recolor the site, add a blog post, publish, and roll back.
+The full source for **diligentservices.io** lives in a public repository on GitHub:
+
+**[github.com/samstevenm/diligentservices-quarto](https://github.com/samstevenm/diligentservices-quarto)**
+
+Every page, color, and word you see is in there. The site is built with [Quarto](https://quarto.org/) and is meant to be hand-maintained: each page is plain Markdown, and a non-technical, step-by-step guide lives in **[EDITING.md](https://github.com/samstevenm/diligentservices-quarto/blob/main/EDITING.md)**.
+
+## Why we publish the source
+
+We point to the repo because we try to be as transparent as possible in everything we build, from websites, to construction projects, to business strategies. This page describes exactly what the repository is and what it contains, so anyone can read the source, check our work, or learn from how the site is put together.
+
+For a note on how the site and our apps are written, see [How this site is made](g611/index.qmd).
 
 ## What's changed (2026-06-25 refresh)
 
-A light refresh focused on honest, generic, easy-to-maintain content:
+- Repositioned from "general contractor / remodeler" to **lighting & control integration** for high-end residential and commercial spaces.
+- A light, clean theme (warm cream, one brass accent) with a documented stylesheet.
+- Every page is plain Markdown, with no client names or project specifics.
+- A non-technical editing guide and safe, rollback-able deploy tooling.
+- A legal-entity footer and a live `/support` page.
+- One canonical AI-authorship colophon at `/g611/`, linked in the footer.
+- The Mitsubishi mini-split blog series links its open-source code at [minisplit-local-public](https://github.com/samstevenm/minisplit-local-public).
 
-- **Repositioned** from "general contractor / remodeler" to **lighting & control integration** for high-end residential and commercial spaces.
-- **Light, clean theme** (warm cream + one brass accent, `cosmo` base) replacing the old construction-orange look. Colors are documented, named variables at the top of `styles/custom.scss`.
-- **Every page is plain Markdown** now — no custom HTML — so anyone can hand-edit the words.
-- **No client names or project specifics** anywhere; capability copy is generic.
-- **New editing guide** (`EDITING.md`) and **safe deploy tooling**: `publish.sh` backs up the live site and auto-rolls-back on failure; `rollback.sh` reverts to any prior version.
-- **Legal-entity footer** ("Diligent Services is a DBA of Carmelita Enterprises Inc.") plus a live `/support` page, for Apple Developer compliance.
-- **One canonical AI-authorship colophon** at `/g611/`, linked site-wide in the footer.
-- **Blog:** the Mitsubishi mini-split Part 2 post now links its open-source code at **[minisplit-local-public](https://github.com/samstevenm/minisplit-local-public)** (MIT, standard-library Python).
-
-## Project Structure
+## Project structure
 
 - `_quarto.yml`: site config (nav, footer, theme, fonts).
 - `index.qmd`, `services.qmd`, `about.qmd`, `contact.qmd`: the main pages.
 - `support/index.qmd`: the public support page.
-- `g611/index.qmd`: the AI-authorship colophon (linked in the footer); `_g611.qmd` is a short include that points at it.
+- `g611/index.qmd`: the AI-authorship colophon (linked in the footer).
 - `blog/*`: blog posts.
 - `styles/custom.scss`: theme colors and fonts (documented, named variables at the top).
-- `EDITING.md`: **start here to update the site by hand.**
+- `EDITING.md`: start here to update the site by hand.
 - `publish.sh` / `rollback.sh`: safe, rollback-able deploy scripts (run on the server).
 - `images/`: favicons and image assets.
-- `_site/`: generated output (git-ignored).
-- `cloud-config.yaml`: cloud-init for initial server setup.
-- `README_.qmd`: this file (symlinked to `README.md`).
+- `README_.qmd`: this page (symlinked to `README.md`).
 
-## Attribution
+## Updating the site
 
-This site was created using [Quarto](https://quarto.org/), an open-source scientific and technical publishing system developed and maintained by RStudio, PBC and the open-source community. 
+To change the site, edit the plain-Markdown pages and follow the step-by-step guide in **[EDITING.md](https://github.com/samstevenm/diligentservices-quarto/blob/main/EDITING.md)**. Publishing and rolling back are one-command scripts on the server (`publish.sh` and `rollback.sh`); every published version is a git commit, so a previous version can always be put back.
 
-Learn more about Quarto at [quarto.org](https://quarto.org/).
+## Hosting
 
-## License
+The site is hosted on a [Hetzner](https://www.hetzner.com/) instance, with the domain managed by Namecheap and a Let's Encrypt certificate. Neither Hetzner nor Namecheap is a paid sponsor; we just like their products.
 
-This project is licensed under the Creative Commons Attribution 4.0 International (CC BY 4.0) license. You are free to copy, modify, and distribute this work, provided you give appropriate credit.
+## Attribution and license
 
-Learn more about the license at [creativecommons.org/licenses/by/4.0](https://creativecommons.org/licenses/by/4.0/).
-
-### Hosting and Domain
-
-This site is hosted on a basic Hetnzer instance, and the domain is managed by Namecheap. Neither Hetnzer nor Namecheap are paid sponsors, but I really like their product.
-
-### Transparency and Readme
-
-This README describes exactly what this repository is and what it contains. The site points to the repo in an effort to be as transparent as possible in everything we build, from websites, to construction projects, to business strategies. The `README_.qmd` file is symbolically linked to `README.qmd` to keep them synced.
-
-## Setup and Deployment
-
-### Prerequisites
-
-- Install [Quarto](https://quarto.org/docs/get-started/installation.html)
-- Install [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
-
-### Initial Server Setup
-
-1. **Generate SSH Key** (if you don't have one):
-
-    ```bash
-    ssh-keygen -t rsa -b 4096 -C "your_email@example.com"
-    ```
-
-2. **Add SSH Key to SSH Agent**:
-
-    ```bash
-    eval "$(ssh-agent -s)"
-    ssh-add ~/.ssh/ssgh.pem
-    ```
-
-3. **Set Correct Permissions**:
-
-    ```bash
-    chmod 600 ~/.ssh/ssgh.pem
-    ```
-
-4. **Add SSH Key to GitHub**:
-
-    ```bash
-    cat ~/.ssh/ssgh.pem.pub
-    ```
-
-    - Copy the output and add it to your GitHub account under [SSH and GPG keys](https://github.com/settings/keys).
-
-5. **Verify SSH Connection to GitHub**:
-
-    ```bash
-    ssh -i ~/.ssh/ssgh.pem -T git@github.com
-    ```
-
-    You should see a message like:
-
-    ```
-    Hi <USERNAME>! You've successfully authenticated, but GitHub does not provide shell access.
-    ```
-
-6. **Configure SSH to Use the Specific Key**:
-
-    ```bash
-    vim ~/.ssh/config
-    ```
-
-    Add the following configuration:
-
-    ```plaintext
-    Host github.com
-    HostName github.com
-    User git
-    IdentityFile ~/.ssh/ssgh.pem
-    ```
-
-    Save and exit the file (`:wq` *w*rites, then *q*uits vim. you heard it here again).
-
-7. **Clone the Repository on the Server**:
-
-    ```bash
-    cd /var/www/<SITENAME>
-    git clone git@github.com:<USERNAME>/<REPONAME>.git
-    ```
-
-8. **Obtain SSL Certificates**:
-
-    ```bash
-    sudo certbot certonly --webroot -w /var/www/<SITENAME>/<REPONAME>/_site -d <SITENAME.TLD> -d www.<SITENAME.TLD>
-    ```
-
-## Local Development
-
-9. **Clone the Repository Locally**:
-
-    ```bash
-    git clone git@github.com:<USERNAME>/<REPONAME>.git
-    cd <REPONAME>
-    ```
-
-10. **Edit Content and Styles**:
-
-    - Edit `.qmd` files to change content.
-    - Edit `styles/custom.scss` for custom styles.
-    - Add images to the `images/` directory.
-
-11. **Generate the Site Locally**:
-
-    ```bash
-    quarto render
-    ```
-
-12. **Commit and Push Changes to GitHub**:
-
-    ```bash
-    git add .
-    git commit -m "Updated content and styles"
-    git push origin main
-    ```
-
-## Updating the Site on the Server (publish + roll back)
-
-The live site does **not** update automatically. To publish, SSH into the server and run the safe publish script:
-
-```bash
-cd /var/www/diligentservices/diligentservices-quarto
-git pull
-./publish.sh
-```
-
-`publish.sh` backs up the current live site, pulls, activates the Python venv (required, or the computational blog posts fail to build), renders, and **automatically restores the previous version if anything fails** — so the live site is never left half-broken. It prints the previous commit so you can roll back. nginx serves the rendered `_site/` directly; no reload needed.
-
-To **roll back** to a previous version (every published version is just a git commit, so nothing is ever lost):
-
-```bash
-./rollback.sh <commit>              # e.g. ./rollback.sh dc8e93d  (find commits with: git log --oneline)
-git checkout main && ./publish.sh   # return to the latest when you're ready
-```
-
-See **[EDITING.md](EDITING.md)** for the full, non-technical walkthrough of editing and publishing.
-
-## Nginx Folder Structure
-
-- `/etc/nginx/nginx.conf`: Main Nginx configuration file.
-- `/etc/nginx/sites-available/<SITENAME>`: Site-specific Nginx configuration file.
-- `/etc/nginx/sites-enabled/<SITENAME>`: Symlink to the site-specific configuration file.
-- `/var/www/<SITENAME>/`: Directory containing the website files.
-- `/var/www/<SITENAME>/<REPONAME>/_site/`: Directory containing the generated site files.
-
-## GitHub Folder Structure
-
-- `<REPONAME>/`: Root directory of the Quarto project.
-- `<REPONAME>/_quarto.yml`: Quarto configuration file.
-- `<REPONAME>/index.qmd`: Main page content.
-- `<REPONAME>/about.qmd`: About page content.
-- `<REPONAME>/contact.qmd`: Contact page content.
-- `<REPONAME>/styles/custom.scss`: Custom CSS styles.
-- `<REPONAME>/images/logo.png`: Company logo image.
-- `<REPONAME>/_site/`: Generated site files.
-- `<REPONAME>/.gitignore`: Git ignore file.
-- `<REPONAME>/cloud-config.yaml`: Cloud-init script.
-- `<REPONAME>/README.qmd`: This meta explanation file.
-
-### Customization
-
-- Edit `.qmd` files to change content.
-- Edit `styles/custom.scss` for custom styles.
-- Add images to the `images/` directory.
+Built with [Quarto](https://quarto.org/), an open-source publishing system. This project is licensed under [Creative Commons Attribution 4.0 (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/): you are free to copy, modify, and distribute it with appropriate credit.

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -6,12 +6,12 @@ project:
 website:
   title: "Diligent Services"
   site-url: https://diligentservices.io
-  description: "Diligent Services designs, installs, and programs lighting, AV, control, and networking for high-end residential and commercial spaces across California and Nevada. A DBA of Carmelita Enterprises Inc, CSLB 1132892."
+  description: "Diligent Services designs, installs, and programs lighting, AV, control, and networking for high-end residential and commercial spaces in California. A DBA of Carmelita Enterprises Inc, CSLB 1132892."
   repo-url: https://github.com/samstevenm/diligentservices-quarto/
   repo-actions: [issue]
   favicon: images/favicon.ico
   page-footer:
-    left: "Diligent Services · Lighting & Control Integration · California & Nevada"
+    left: "Diligent Services · Lighting & Control Integration · California"
     center: "Diligent Services is a DBA of Carmelita Enterprises Inc."
     right:
       - text: "Support"
@@ -36,6 +36,8 @@ website:
         href: contact.qmd
       - text: "Support"
         href: support/index.qmd
+      - text: "Docs"
+        href: README_.qmd
     right:
       - icon: linkedin
         href: https://www.linkedin.com/in/samstevenmyers/
@@ -54,4 +56,4 @@ format:
       - text: |
           <link rel="preconnect" href="https://fonts.googleapis.com">
           <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-          <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+          <link href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;500;600&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">

--- a/about.qmd
+++ b/about.qmd
@@ -10,7 +10,7 @@ toc: true
 
 ---
 
-Diligent Services is a family-run lighting and control integration firm (_[CSLB 1132892](https://www.cslb.ca.gov/OnlineServices/checklicenseII/LicenseDetail.aspx?LicNum=1132892)_) serving high-end residential and commercial clients. Founded in 2002 by Tony and Barbara Myers in the SF Bay Area, the operation is now run by Sam and Pearl Myers. We design, install, and program lighting, audio/visual, control, and networking - the quiet infrastructure that makes a home or a commercial space feel effortless. We thrive on referral business.
+Diligent Services is a family-run lighting and control integration firm (_[CSLB 1132892](https://www.cslb.ca.gov/OnlineServices/checklicenseII/LicenseDetail.aspx?LicNum=1132892)_) serving high-end residential and commercial clients. Founded in 2002 by Tony and Barbara Myers in the SF Bay Area, the operation is now run by Sam and Pearl Myers. We design, install, and program lighting, audio/visual, control, and networking, the quiet infrastructure a home or commercial space depends on. Most of our work comes by referral.
 
 ### Personal Touch
 

--- a/contact.qmd
+++ b/contact.qmd
@@ -6,10 +6,10 @@ toc: false
 
 ### Let's talk.
 
-Most of our work starts with a conversation. Tell us about your space - a home or a commercial interior - and what you want it to do, and we will take it from there.
+Most of our work starts with a conversation. Tell us about your space, whether a home or a commercial interior, and what you want it to do, and we will take it from there.
 
 - **Email:** [info@diligentservices.io](mailto:info@diligentservices.io)
 - **Phone:** (424) 448-5200
-- **Service area:** California and Nevada
+- **Service area:** California
 
 Already a client and need a hand? Head to [Support](support/index.qmd).

--- a/index.qmd
+++ b/index.qmd
@@ -1,11 +1,11 @@
 ---
-title: "Light. Control. Effortless."
-subtitle: "Lighting and control integration for high-end homes and commercial spaces."
+title: "Lighting and control, done right."
+subtitle: "Design, installation, and programming for high-end homes and commercial spaces."
 pagetitle: "Diligent Services — Lighting & Control Integration"
 toc: false
 ---
 
-Diligent Services designs, installs, and programs the lighting, audio/visual, control, and networking systems that make a space feel effortless. We are a small, family-run firm, and we carry a project from design through programming and the support that follows, so the technology stays out of the way.
+Diligent Services designs, installs, and programs the lighting, audio/visual, control, and networking that a high-end home or commercial space runs on. We are a small, family-run firm, and we carry a project from design through programming and the support that follows, so the technology stays out of the way.
 
 [Start a project](contact.qmd){.btn .btn-primary} [See our services](services.qmd){.btn .btn-outline-secondary}
 

--- a/services.qmd
+++ b/services.qmd
@@ -6,7 +6,7 @@ toc: true
 toc-title: "On this page"
 ---
 
-We design, install, and program integrated lighting and control systems for high-end homes and commercial spaces. The work is the same discipline at every scale: get the light, the sound, the control, and the network right, then make them disappear into a space that simply works.
+We design, install, and program integrated lighting and control systems for high-end homes and commercial spaces. The work is the same discipline at every scale: get the light, the sound, the control, and the network right, then keep them out of the way so the space just works.
 
 ## Lighting and Tunable Light
 
@@ -18,7 +18,7 @@ Distributed audio, home theater, and display systems. We handle the room acousti
 
 ## Control and Automation
 
-One coherent control layer over lighting, shades, climate, audio, and video. We program the platforms that run the room, on a keypad, a touchscreen, or a phone, so a single press sets a scene. The goal is fewer decisions for the client, not more screens.
+One coherent control layer over lighting, shades, climate, audio, and video. We program the platforms that run the room, on a keypad, a touchscreen, or a phone, so a single press sets a scene. The goal is fewer decisions for the client and fewer screens to learn.
 
 ## Networking, Security, and Infrastructure
 

--- a/styles/custom.scss
+++ b/styles/custom.scss
@@ -11,8 +11,8 @@
 $ds-cream:   #FBF9F4;  // page background (warm off-white)
 $ds-ink:     #23201A;  // body + heading text (warm near-black)
 $ds-muted:   #6B655B;  // secondary / lighter text
-$ds-brass:   #9A6B1E;  // the one warm accent (buttons, active nav, rules)
-$ds-link:    #7E5615;  // link text (a touch darker so it stays readable)
+$ds-brass:   #9A6B1E;  // warm accent (active nav, rules)
+$ds-link:    #7E5615;  // links + buttons (darker brass, clears WCAG AA)
 $ds-hair:    #E7E1D6;  // hairlines / borders
 
 // Map our palette onto the theme. Usually no need to touch these.
@@ -26,11 +26,14 @@ $border-color:     $ds-hair;
 $navbar-bg: $ds-cream;
 $navbar-fg: $ds-ink;
 $navbar-hl: $ds-brass;
-$footer-bg: #F3EFE7;
+$footer-bg: #EFEAE0;   // a touch deeper than the page so the footer separates
 $footer-fg: $ds-muted;
 
 $font-family-sans-serif: 'Inter', system-ui, -apple-system, "Segoe UI", sans-serif;
-$headings-font-family:   'Fraunces', Georgia, "Times New Roman", serif;
+// Display serif. NOTE: avoid "ff"/"fi"/"fl" inside headings — some serifs fuse
+// them into an ugly ligature. Ligatures are turned off on headings below as a
+// safety net, but it is still cleaner to pick heading words without f-pairs.
+$headings-font-family:   'Spectral', Georgia, "Times New Roman", serif;
 $headings-font-weight:   600;
 $headings-color:         $ds-ink;
 $body-line-height:       1.65;
@@ -38,14 +41,32 @@ $body-line-height:       1.65;
 /*-- scss:rules --*/
 
 body { -webkit-font-smoothing: antialiased; }
-h1, h2, h3 { letter-spacing: -0.01em; }
+
+// Headings: ligatures off so f-pairs never fuse, and gentle tracking for the serif.
+h1, h2, h3, h4, h5, h6, .quarto-title-block .title, .navbar-brand {
+  font-variant-ligatures: no-common-ligatures no-discretionary-ligatures;
+  font-feature-settings: "liga" 0, "dlig" 0, "calt" 0;
+}
 
 // Make the homepage title (front-matter "title:") read as a hero.
-.quarto-title-block .title { font-size: clamp(2.2rem, 5vw, 3.4rem); line-height: 1.08; }
+.quarto-title-block .title {
+  font-size: clamp(2.2rem, 5vw, 3.4rem);
+  line-height: 1.1;
+  letter-spacing: -0.005em;
+}
 .quarto-title-block .subtitle { color: $ds-muted; font-weight: 400; }
 
 .navbar { border-bottom: 1px solid $ds-hair; }
 .navbar-brand { font-family: $headings-font-family; font-weight: 600; }
 
-// A little breathing room between stacked buttons on the homepage.
+// Footer: a defined top edge so it separates from the page.
+.nav-footer { border-top: 1px solid $ds-hair; }
+
+// Buttons. Primary uses the darker brass so the white label clears WCAG AA.
 .btn { margin: 0.25rem 0.4rem 0.25rem 0; }
+.btn-primary { background-color: $ds-link; border-color: $ds-link; }
+.btn-primary:hover { background-color: darken($ds-link, 6%); border-color: darken($ds-link, 6%); }
+
+// Secondary CTA: brass-toned outline instead of stock Bootstrap gray.
+.btn-outline-secondary { color: $ds-link; border-color: $ds-hair; }
+.btn-outline-secondary:hover { background-color: $ds-cream; border-color: $ds-brass; color: $ds-brass; }


### PR DESCRIPTION
Acts on a 4-lens critical review (copy, typography, IA, correctness). Removes "effortless" site-wide + new hero; swaps Fraunces→Spectral (kills the ugly ff ligature) + disables heading ligatures; restores a prominent **Docs** nav page leading with the public repo link + transparency statement (drops SSH/vim boilerplate); WCAG-AA primary button; footer separation; and drops the **Nevada** service-area claim (only a CA license is shown) pending Sam's NSCB confirmation.